### PR TITLE
Updated Catboost reranking with train, val, test

### DIFF
--- a/experiments/subgraphs_reranking/graph_features/catboost_features.ipynb
+++ b/experiments/subgraphs_reranking/graph_features/catboost_features.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -11,7 +11,7 @@
        "device(type='cuda')"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -26,29 +26,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2024, 3, 18, 8, 42, 35, 590823)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import datetime\n",
-    "\n",
-    "now = datetime.datetime.now()\n",
-    "now"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -57,7 +34,7 @@
     "In the cell below, you can configure what type of training. For instance, you can choose what type of sequence to train catboost on (both, gap, or g2t); or what kind of dataset (either xl or large). The following options are valid:\n",
     "\n",
     "* `finetune`: to whether do gridsearch on catboost, or just use default params\n",
-    "* `sequence_type`: choices=[both, gap, or g2t] where both means both gap and g2t as features\n",
+    "* `sequence_type`: choices=[determ, gap, or g2t] \n",
     "* `ds_type`: either T5-large-ssm or T5-xl-ssm. The graph features dataset (`features_ds_path`) and the seq2seq outputs dataset (`test_csv_path`) will be depended on the specified model from this argument.\n",
     "* model_weights: None or the provided model weight, if None, train from scratch\n",
     "* `save_path`: model weights, reranking results and features importance will be saved in this folder\n"
@@ -65,44 +42,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
-    "finetune = True\n",
+    "# None if training from scratch, else eveuating\n",
+    "model_weights = (\n",
+    "   None #\"/workspace/storage/misc/features_reranking/no_cherries_fixed_train_g2t_xl/best_model\"\n",
+    ")\n",
     "with_tdidf = False\n",
     "num_iters = 100000\n",
-    "sequence_type = \"all\"\n",
+    "sequence_type = \"gap\"\n",
     "ds_type = \"large\"\n",
     "test_csv_path = f\"hle2000/Mintaka_T5_{ds_type}_ssm_outputs\"\n",
     "features_ds_path = f\"s-nlp/Mintaka_Graph_Features_T5-{ds_type}-ssm\"\n",
-    "model_weights = None\n",
-    "save_path = f\"/workspace/storage/misc/features_reranking/{sequence_type}_tfidf_{with_tdidf}_{ds_type}/\"\n",
-    "cache_path = \"/workspace/storage/misc/huggingface\""
+    "\n",
+    "finetune = False if model_weights else False\n",
+    "save_path = f\"/workspace/storage/misc/features_reranking/no_cherries_fixed_train_{sequence_type}_{ds_type}/\"\n",
+    "cache_path = \"/workspace/storage/misc/huggingface\"\n",
+    "if not model_weights:\n",
+    "    Path(save_path).mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ast import literal_eval\n",
-    "import pandas as pd\n",
-    "\n",
-    "\n",
-    "def try_literal_eval(s):\n",
-    "    try:\n",
-    "        return literal_eval(s)\n",
-    "    except ValueError:\n",
-    "        return s"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,45 +95,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pathlib\n",
-    "import shutil\n",
-    "\n",
-    "\n",
-    "def remove_cache():\n",
-    "    home_dir = pathlib.Path.home()\n",
-    "    dataset_dir = home_dir / \".cache\" / \"huggingface\" / \"datasets\"\n",
-    "\n",
-    "    shutil.rmtree(str(dataset_dir))\n",
-    "\n",
-    "\n",
-    "remove_cache()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Found cached dataset parquet (/workspace/storage/misc/huggingface/hle2000___parquet/hle2000--Mintaka_Graph_Features_Updated_T5-large-ssm-4e10b61230716f57/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec)\n"
+      "Found cached dataset parquet (/workspace/storage/misc/huggingface/s-nlp___parquet/s-nlp--Mintaka_Graph_Features_T5-xl-ssm-b86a615720d5466b/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec)\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "41522d23a5a54c639264f7bd11ea58d3",
+       "model_id": "8a482c61db094d87af6450eba96a2aee",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/2 [00:00<?, ?it/s]"
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -179,12 +125,20 @@
     "\n",
     "graph_features_ds = load_dataset(features_ds_path, cache_dir=cache_path)\n",
     "processed_train_df = graph_features_ds[\"train\"].to_pandas()\n",
+    "processed_val_df = graph_features_ds[\"validation\"].to_pandas()\n",
     "processed_test_df = graph_features_ds[\"test\"].to_pandas()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Processing Numeric Features"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,52 +163,60 @@
     "min_max_scaler = preprocessing.MinMaxScaler()\n",
     "\n",
     "\n",
-    "def apply_col_scale(df, col):\n",
+    "def apply_col_scale(df, col, scale_type):\n",
     "    \"\"\"apply min max scaling\"\"\"\n",
-    "    df[col] = min_max_scaler.fit_transform(df[col])\n",
+    "    if scale_type == 'train':\n",
+    "        df[col] = min_max_scaler.fit_transform(df[col])\n",
+    "    else:\n",
+    "        df[col] = min_max_scaler.transform(df[col])\n",
     "    return df\n",
-    "\n",
     "\n",
     "# get the numerica cols in train and test to scale\n",
     "train_numeric_cols = get_numeric_cols(processed_train_df)\n",
+    "val_numeric_cols = get_numeric_cols(processed_val_df)\n",
     "test_numeric_cols = get_numeric_cols(processed_test_df)\n",
     "\n",
-    "processed_train_df = apply_col_scale(processed_train_df, train_numeric_cols)\n",
-    "processed_test_df = apply_col_scale(processed_test_df, test_numeric_cols)"
+    "processed_train_df = apply_col_scale(processed_train_df, train_numeric_cols, 'train')\n",
+    "processed_val_df = apply_col_scale(processed_val_df, val_numeric_cols, 'val')\n",
+    "processed_test_df = apply_col_scale(processed_test_df, test_numeric_cols, 'test')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Processing Text and Embedding Features"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "def filter_df_sequence(dataframe, seq_type):\n",
     "    \"\"\"filter df base on the sequence type,\n",
     "    return filtered df & textual + embedding features\"\"\"\n",
-    "\n",
     "    textual_feat = [\"determ_sequence\", \"g2t_sequence\", \"gap_sequence\"]\n",
-    "    if seq_type != \"all\":\n",
-    "        if seq_type == \"g2t\":\n",
-    "            rm_lst = [\"determ_sequence\", \"gap_sequence\"]\n",
-    "        elif seq_type == \"determ\":\n",
-    "            rm_lst = [\"g2t_sequence\", \"gap_sequence\"]\n",
-    "        elif seq_type == \"gap\":\n",
-    "            rm_lst = [\"determ_sequence\", \"g2t_sequence\"]\n",
-    "        drop_text_cols = [item for item in textual_feat if item in rm_lst]\n",
-    "        drop_em_cols = [f\"{feat}_embedding\" for feat in drop_text_cols]\n",
-    "        dataframe = dataframe.drop(drop_text_cols + drop_em_cols, axis=1)\n",
-    "        textual_feat = [f\"{seq_type}_sequence\"]\n",
-    "        emb_feat = [f\"{seq_type}_sequence_embedding\"]\n",
-    "    else:\n",
-    "        emb_feat = [f\"{feat}_embedding\" for feat in textual_feat]\n",
-    "\n",
+    "    \n",
+    "    if seq_type == \"g2t\":\n",
+    "        rm_lst = [\"determ_sequence\", \"gap_sequence\"]\n",
+    "    elif seq_type == \"determ\":\n",
+    "        rm_lst = [\"g2t_sequence\", \"gap_sequence\"]\n",
+    "    elif seq_type == \"gap\":\n",
+    "        rm_lst = [\"determ_sequence\", \"g2t_sequence\"]\n",
+    "    drop_text_cols = [item for item in textual_feat if item in rm_lst]\n",
+    "    drop_em_cols = [f\"{feat}_embedding\" for feat in drop_text_cols]\n",
+    "    dataframe = dataframe.drop(drop_text_cols + drop_em_cols, axis=1)\n",
+    "    textual_feat = [f\"{seq_type}_sequence\"]\n",
+    "    emb_feat = [f\"{seq_type}_sequence_embedding\"]\n",
+    "    \n",
     "    return dataframe, textual_feat, emb_feat"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,6 +225,7 @@
     "processed_train_df, textual_feats, embd_feats = filter_df_sequence(\n",
     "    processed_train_df, sequence_type\n",
     ")\n",
+    "processed_val_df, _, _ = filter_df_sequence(processed_val_df, sequence_type)\n",
     "processed_test_df, _, _ = filter_df_sequence(processed_test_df, sequence_type)\n",
     "text_features += textual_feats\n",
     "emb_features += embd_feats"
@@ -270,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,29 +245,17 @@
     "\n",
     "\n",
     "processed_train_df = process_text_features(processed_train_df, text_features)\n",
+    "processed_val_df = process_text_features(processed_val_df, text_features)\n",
     "processed_test_df = process_text_features(processed_test_df, text_features)\n",
     "\n",
     "processed_train_df = processed_train_df.dropna()\n",
+    "processed_val_df = processed_val_df.dropna()\n",
     "processed_test_df = processed_test_df.dropna()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# dropping tfidf\n",
-    "if not with_tdidf:\n",
-    "    processed_train_df = processed_train_df.drop(\"tfidf_vector\", axis=1)\n",
-    "    processed_test_df = processed_test_df.drop(\"tfidf_vector\", axis=1)\n",
-    "else:  # with tfidf\n",
-    "    emb_features.append(\"tfidf_vector\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -312,7 +263,6 @@
      "output_type": "stream",
      "text": [
       "question_answer_embedding\n",
-      "determ_sequence_embedding\n",
       "g2t_sequence_embedding\n"
      ]
     }
@@ -322,26 +272,32 @@
     "for e_f in emb_features:\n",
     "    print(e_f)\n",
     "    processed_train_df[e_f] = processed_train_df[e_f].apply(str_to_arr)\n",
+    "    processed_val_df[e_f] = processed_val_df[e_f].apply(str_to_arr)\n",
     "    processed_test_df[e_f] = processed_test_df[e_f].apply(str_to_arr)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "drop_cols = [\"correct\", \"question\"]\n",
+    "# dropping TDA tfidf\n",
+    "processed_train_df = processed_train_df.drop(\"tfidf_vector\", axis=1)\n",
+    "processed_val_df = processed_val_df.drop(\"tfidf_vector\", axis=1)\n",
+    "processed_test_df = processed_test_df.drop(\"tfidf_vector\", axis=1)\n",
     "\n",
+    "# preparing data for catboost training\n",
+    "drop_cols = [\"correct\", \"question\"]\n",
     "X_train = processed_train_df.drop(drop_cols, axis=1)\n",
     "y_train = processed_train_df[\"correct\"].tolist()\n",
-    "X_test = processed_test_df.drop(drop_cols, axis=1)\n",
-    "y_test = processed_test_df[\"correct\"].tolist()"
+    "X_test = processed_val_df.drop(drop_cols, axis=1)\n",
+    "y_test = processed_val_df[\"correct\"].tolist()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +346,6 @@
     "    text_features=text_features,\n",
     "    feature_names=list(X_test),\n",
     "    embedding_features=emb_features,\n",
-    "    weight=find_weight(y_test),\n",
     ")"
    ]
   },
@@ -403,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -452,7 +407,6 @@
     "    model = CatBoostRegressor()  # parameters not required.\n",
     "    model.load_model(model_weights)\n",
     "else:  # train from scratch\n",
-    "    Path(save_path).mkdir(parents=True, exist_ok=True)\n",
     "    print(\"training from scratch\")\n",
     "    model = CatBoostRegressor(\n",
     "        iterations=num_iters,\n",
@@ -478,39 +432,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fab457c5543d4d5aa7b18bd922e65493",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading readme:   0%|          | 0.00/8.38k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Found cached dataset parquet (/workspace/storage/misc/huggingface/hle2000___parquet/hle2000--Mintaka_T5_large_ssm_outputs-f31d696c971a731a/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec)\n"
+      "Found cached dataset parquet (/workspace/storage/misc/huggingface/hle2000___parquet/hle2000--Mintaka_T5_xl_ssm_outputs-059583fb07b6dc35/0.0.0/2a3b91fbd88a2c90d1dbbb32b460cf621d31bd5b05b934492fdef7d8d6f236ec)\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "caa534cdceb04116bc9b836b797c45df",
+       "model_id": "a5fff45000694e2a97b506187897678f",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/2 [00:00<?, ?it/s]"
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -518,37 +458,98 @@
     }
    ],
    "source": [
-    "from datasets import load_dataset\n",
-    "\n",
-    "test_res_csv = load_dataset(\n",
+    "from datasets import load_dataset, DatasetDict, Dataset\n",
+    "seq2seq_outputs = load_dataset(\n",
     "    test_csv_path, verification_mode=\"no_checks\", cache_dir=cache_path\n",
-    ")[\"test\"].to_pandas()"
+    ")\n",
+    "train_seq2seq = seq2seq_outputs['train'].to_pandas()\n",
+    "test_seq2seq = seq2seq_outputs['test'].to_pandas()\n",
+    "val_seq2seq = seq2seq_outputs['validation'].to_pandas()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tqdm import tqdm\n",
+    "def rerank(test_df, seq2seq_res, black_list):\n",
+    "    final_acc, top200_total, top1_total, seq2seq_correct = 0, 0, 0, 0\n",
+    "    exclude = 0\n",
+    "\n",
+    "    for idx, group in tqdm(seq2seq_res.iterrows()):\n",
+    "        curr_question_df = test_df[\n",
+    "            test_df[\"question\"] == group[\"question\"]\n",
+    "        ]\n",
+    "        if group['question'] in black_list:\n",
+    "            exclude += 1\n",
+    "            continue\n",
+    "        curr_question_df = curr_question_df.drop(\"question\", axis=1)\n",
+    "        \n",
+    "        if (\n",
+    "            len(curr_question_df) == 0\n",
+    "        ):  # we don't have subgraph for this question, take answer from seq2seq\n",
+    "            if group[\"answer_0\"] == group[\"target\"]:\n",
+    "                seq2seq_correct += 1\n",
+    "            else:  # check if answer exist in 200 beams for question with no subgraphs\n",
+    "                all_beams = group.tolist()[2:-1]  # all 200 beams\n",
+    "                all_beams = set(all_beams)\n",
+    "                top200_total += 1 if group[\"target\"] in all_beams else 0\n",
+    "\n",
+    "        else:  # we have subgraph for this question\n",
+    "            all_beams = group.tolist()[2:-1]  # all 200 beams\n",
+    "            all_beams = set(all_beams)\n",
+    "\n",
+    "            if group[\"target\"] not in all_beams:  # no correct answer in beam\n",
+    "                continue\n",
+    "\n",
+    "            # correct answer exist in beam\n",
+    "            top1_total += 1 if group[\"answer_0\"] == group[\"target\"] else 0\n",
+    "            top200_total += 1\n",
+    "\n",
+    "            is_corrects = curr_question_df[\"correct\"].astype(bool).tolist()\n",
+    "            curr_rows = curr_question_df.drop([\"correct\"], axis=1)\n",
+    "\n",
+    "            preds = model.predict(curr_rows)\n",
+    "            max_idx = preds.argmax()\n",
+    "\n",
+    "            if is_corrects[max_idx] is True:\n",
+    "                final_acc += 1\n",
+    "\n",
+    "    # final reranking, top1 and top200 result\n",
+    "    reranking_res = (final_acc + seq2seq_correct) / (len(seq2seq_res) - exclude)\n",
+    "    top200 = (top200_total + seq2seq_correct) / (len(seq2seq_res) - exclude)\n",
+    "    top1 = (top1_total + seq2seq_correct) / (len(seq2seq_res) - exclude)\n",
+    "    return reranking_res, top1, top200"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### None filtered re-ranking (4000 questions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "0it [00:00, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "4000it [00:22, 179.63it/s]"
+      "2000it [00:16, 124.47it/s]\n",
+      "4000it [00:27, 146.64it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "top1: 0.25425, top200: 0.64375, reranking top1: 0.28775\n"
+      "Val: reranked@1: 0.374, original@1: 0.3275, @200: 0.686\n",
+      "Test: reranked@1: 0.3275, original@1: 0.31725, @200: 0.69025\n"
      ]
     },
     {
@@ -560,55 +561,100 @@
     }
    ],
    "source": [
-    "from tqdm import tqdm\n",
-    "\n",
-    "final_acc, top200_total, top1_total, seq2seq_correct = 0, 0, 0, 0\n",
-    "\n",
-    "for idx, group in tqdm(test_res_csv.iterrows()):\n",
-    "    curr_question_df = processed_test_df[\n",
-    "        processed_test_df[\"question\"] == group[\"question\"]\n",
-    "    ]\n",
-    "    curr_question_df = curr_question_df.drop(\"question\", axis=1)\n",
-    "\n",
-    "    if (\n",
-    "        len(curr_question_df) == 0\n",
-    "    ):  # we don't have subgraph for this question, take answer from seq2seq\n",
-    "        if group[\"answer_0\"] == group[\"target\"]:\n",
-    "            seq2seq_correct += 1\n",
-    "        else:  # check if answer exist in 200 beams for question with no subgraphs\n",
-    "            all_beams = group.tolist()[2:-1]  # all 200 beams\n",
-    "            all_beams = set(all_beams)\n",
-    "            top200_total += 1 if group[\"target\"] in all_beams else 0\n",
-    "\n",
-    "    else:  # we have subgraph for this question\n",
-    "        all_beams = group.tolist()[2:-1]  # all 200 beams\n",
-    "        all_beams = set(all_beams)\n",
-    "\n",
-    "        if group[\"target\"] not in all_beams:  # no correct answer in beam\n",
-    "            continue\n",
-    "\n",
-    "        # correct answer exist in beam\n",
-    "        top1_total += 1 if group[\"answer_0\"] == group[\"target\"] else 0\n",
-    "        top200_total += 1\n",
-    "\n",
-    "        is_corrects = curr_question_df[\"correct\"].astype(bool).tolist()\n",
-    "        curr_rows = curr_question_df.drop([\"correct\"], axis=1)\n",
-    "\n",
-    "        preds = model.predict(curr_rows)\n",
-    "        max_idx = preds.argmax()\n",
-    "\n",
-    "        if is_corrects[max_idx] is True:\n",
-    "            final_acc += 1\n",
-    "\n",
-    "\n",
-    "# final rerankinga, top1 and top200 result\n",
-    "reranking_res = (final_acc + seq2seq_correct) / len(test_res_csv)\n",
-    "top200 = (top200_total + seq2seq_correct) / len(test_res_csv)\n",
-    "top1 = (top1_total + seq2seq_correct) / len(test_res_csv)\n",
-    "\n",
+    "val_reranking_res, val_top1, val_top200 = rerank(processed_val_df, val_seq2seq, [])\n",
+    "test_reranking_res, test_top1, test_top200 = rerank(processed_test_df, test_seq2seq, [])\n",
     "with open(Path(save_path) / \"reranking_results\", \"w+\") as f:\n",
-    "    f.write(f\"top1: {top1}, top200: {top200}, reranking top1: {reranking_res}\")\n",
-    "print(f\"top1: {top1}, top200: {top200}, reranking top1: {reranking_res}\")"
+    "    f.write(f\"Val: reranked@1: {val_reranking_res}, original@1: {val_top1}, @200: {val_top200}\\n\")\n",
+    "    f.write(f\"Test: reranked@1: {test_reranking_res}, original@1: {test_top1}, @200: {test_top200}\\n\")\n",
+    "\n",
+    "print(f\"Val: reranked@1: {val_reranking_res}, original@1: {val_top1}, @200: {val_top200}\")\n",
+    "print(f\"Test: reranked@1: {test_reranking_res}, original@1: {test_top1}, @200: {test_top200}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### filtered re-ranking (3200 questions questions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "No config specified, defaulting to: mintaka/en\n",
+      "Found cached dataset mintaka (/workspace/storage/misc/huggingface/AmazonScience___mintaka/en/1.0.0/bb35d95f07aed78fa590601245009c5f585efe909dbd4a8f2a4025ccf65bb11d)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5bcf27f4a70546efa38e7b66f190e52a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def get_black_list(ds):\n",
+    "    exclude_ds = ds[(ds['complexityType'] == 'yesno') | (ds['complexityType'] == 'count')]\n",
+    "    exclude_ques = exclude_ds['question'].tolist()\n",
+    "    return exclude_ques\n",
+    "\n",
+    "mintaka = load_dataset('AmazonScience/mintaka', cache_dir=\"/workspace/storage/misc/huggingface\")\n",
+    "exclude_ques_val = get_black_list(mintaka['validation'].to_pandas())\n",
+    "exclude_ques_test = get_black_list(mintaka['test'].to_pandas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2000it [00:12, 159.10it/s]\n",
+      "4000it [00:27, 145.90it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Val: reranked@1: 0.296875, original@1: 0.300625, @200: 0.6125\n",
+      "Test: reranked@1: 0.3009375, original@1: 0.288125, @200: 0.6203125\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "val_reranking_res, val_top1, val_top200 = rerank(processed_val_df, val_seq2seq, exclude_ques_val)\n",
+    "test_reranking_res, test_top1, test_top200 = rerank(processed_test_df, test_seq2seq, exclude_ques_test)\n",
+    "with open(Path(save_path) / \"filtered_reranking_results\", \"w+\") as f:\n",
+    "    f.write(f\"Val: reranked@1: {val_reranking_res}, original@1: {val_top1}, @200: {val_top200}\\n\")\n",
+    "    f.write(f\"Test: reranked@1: {test_reranking_res}, original@1: {test_top1}, @200: {test_top200}\\n\")\n",
+    "\n",
+    "print(f\"Val: reranked@1: {val_reranking_res}, original@1: {val_top1}, @200: {val_top200}\")\n",
+    "print(f\"Test: reranked@1: {test_reranking_res}, original@1: {test_top1}, @200: {test_top200}\")"
    ]
   },
   {
@@ -620,12 +666,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtgAAAGdCAYAAAAorgRHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABoHUlEQVR4nO3deVxV1f7/8dcRkekwiJKAgTOI5jznhIphv+I6VJp6Qwq1bppTTtwyQU2p1Jxu6bUSLDFtUm+WY4KzoibOqCRiN4qbJQgqIvD7w4f76wkHrKMIvp+Px3482HuvvdZnb0/5YfnZ65gKCwsLERERERERqyhX0gGIiIiIiJQlSrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsERERERErKl/SAYg8aAoKCvjpp59wdnbGZDKVdDgiIiJSDIWFhZw/fx5vb2/Klbv1HLUSbJF77KeffsLHx6ekwxAREZE/4cyZMzz88MO3bKMEW+Qec3Z2Bq7+B+ri4lLC0YiIiEhxZGVl4ePjY/w9fitKsEXusWtlIS4uLkqwRURESpnilHfqJUcREREREStSgi0iIiIiYkVKsEVERERErEgJtoiIiIiIFSnBFhERERGxIiXYIiIiIiJWpARbRERERMSKlGCLiIiIiFiREmwREREREStSgi0iIiIiYkVKsEVERERErEgJtoiIiIiIFSnBFhERERGxovIlHYDIg+qRiWspZ+dY0mGIlDqp0U+UdAgiIrekGWwREREREStSgi0iIiIiYkVKsEVERERErEgJtoiIiIiIFSnBFhERERGxIiXYIiIiIiJWVGYSbJPJxIoVK0o6DCmGwMBARowYYfV+Y2JicHNzu2WbyMhIGjdubOyHhYXRo0cPq8ciIiIiD65Stw52ZGQkK1asYP/+/RbH09PTqVixYskEJaXW7NmzKSwsLOkwREREpAwpdQn2zXh6epZ0CKXK5cuXqVChQkmHUeJcXV1LOgQREREpY+64RCQnJ4fQ0FDMZjNeXl7MmDHD4p/8b1Sq4ebmRkxMjLF/5swZevfujZubG+7u7nTv3p3U1FTjfHx8PC1btsTJyQk3Nzfatm3L6dOniYmJISoqiqSkJEwmEyaTyej3j+MePHiQzp074+DgQKVKlRg8eDDZ2dnG+WulAdOnT8fLy4tKlSoxZMgQ8vLyivUcPv74Y5o3b46zszOenp7069ePjIwMi3swmUxs3LiR5s2b4+joyKOPPkpycrLRJikpiU6dOuHs7IyLiwvNmjVjz549FBYW4uHhweeff260bdy4MV5eXsb+1q1bsbOz48KFCwCcO3eOgQMH4uHhgYuLC507dyYpKclof6004oMPPqBGjRrY29vf9h4LCgqYNm0aNWrUwMHBgUaNGlnEdO0e165dS5MmTXBwcKBz585kZGTw7bffEhAQgIuLC/369TPivObKlSsMHToUV1dXKleuzIQJEyxmknNzcxk9ejRVq1bFycmJVq1aER8fb9FHTEwMvr6+ODo60rNnT86ePVvkHqKjo6lSpQrOzs6Eh4dz6dIli/N/LBEJDAxk2LBhjB07Fnd3dzw9PYmMjLS45tixY7Rr1w57e3vq1avHhg0bVKIkIiIihjtOsMeMGUNCQgIrV65k3bp1xMfHs2/fvmJfn5eXR3BwMM7OzmzZsoVt27ZhNpvp1q0bly9f5sqVK/To0YOOHTty4MABduzYweDBgzGZTPTp04dXX32V+vXrk56eTnp6On369CkyRk5ODsHBwVSsWJHExEQ+++wzNmzYwNChQy3abdq0iZSUFDZt2kRsbCwxMTEWvwjc7j4mT55MUlISK1asIDU1lbCwsCLtXnvtNWbMmMGePXsoX748L7zwgnGuf//+PPzwwyQmJrJ3717Gjx+Pra0tJpOJDh06GAnl77//ztGjR7l48SLHjh0DICEhgRYtWuDoePWrtp955hkjsd27dy9NmzalS5cu/Pbbb8Z4J0+e5IsvvuDLL78sUmJzI9OmTWPx4sXMnz+fw4cPM3LkSP7+97+TkJBg0S4yMpJ58+axfft245enWbNmERcXx+rVq1m3bh1z5861uCY2Npby5cuze/duZs+ezcyZM/nggw+M80OHDmXHjh18+umnHDhwgGeeeYZu3bpx4sQJAHbt2kV4eDhDhw5l//79dOrUiSlTpliMsXz5ciIjI5k6dSp79uzBy8uL995777b3HRsbi5OTE7t27eLtt99m0qRJrF+/HoD8/Hx69OiBo6Mju3bt4t///jevvfbaLfvLzc0lKyvLYhMREZGy645KRLKzs/nwww/55JNP6NKlC3A1GXn44YeL3ceyZcsoKCjggw8+wGQyAbBo0SLc3NyIj4+nefPmZGZm8uSTT1KrVi0AAgICjOvNZjPly5e/ZUlIXFwcly5dYvHixTg5OQEwb948QkJCeOutt6hSpQoAFStWZN68edjY2FC3bl2eeOIJNm7cyKBBg257H9cnyjVr1mTOnDm0aNGC7OxszGazce7NN9+kY8eOAIwfP54nnniCS5cuYW9vT1paGmPGjKFu3boA1KlTx7guMDCQBQsWALB582aaNGmCp6cn8fHx1K1bl/j4eKPfrVu3snv3bjIyMrCzswNg+vTprFixgs8//5zBgwcDV8tCFi9ejIeHx23vLzc3l6lTp7JhwwbatGlj3OfWrVtZsGCBMTbAlClTaNu2LQDh4eFERESQkpJCzZo1AXj66afZtGkT48aNM67x8fHh3XffxWQy4e/vz8GDB3n33XcZNGgQaWlpLFq0iLS0NLy9vQEYPXo0a9asYdGiRUydOpXZs2fTrVs3xo4dC4Cfnx/bt29nzZo1xhizZs0iPDyc8PBwI84NGzYUmcX+o4YNGzJx4kTjz2TevHls3LiRrl27sn79elJSUoiPjzc+g2+++SZdu3a9aX/Tpk0jKirqts9cREREyoY7msFOSUnh8uXLtGrVyjjm7u6Ov79/sftISkri5MmTODs7YzabMZvNuLu7c+nSJVJSUnB3dycsLIzg4GBCQkKYPXs26enpdxImR48epVGjRkZyDdC2bVsKCgosSjTq16+PjY2Nse/l5WVR5nEre/fuJSQkBF9fX5ydnY2EMy0tzaJdw4YNLfoHjDFGjRrFwIEDCQoKIjo6mpSUFKNtx44dOXLkCP/73/9ISEggMDCQwMBA4uPjycvLY/v27QQGBgJXn2l2djaVKlUynqnZbObUqVMWfVarVq1YyTVcne2+cOECXbt2tehz8eLFFn3+8R6rVKmCo6OjkVxfO/bH59q6dWvjFyyANm3acOLECfLz8zl48CD5+fn4+flZjJ2QkGCMffToUYvP4bU+rlecNjdy/f2A5eciOTkZHx8fi1/wWrZsecv+IiIiyMzMNLYzZ87cNgYREREpvaz+kqPJZCqyKsP1dc3Z2dk0a9aMJUuWFLn2WvK3aNEihg0bxpo1a1i2bBmvv/4669evp3Xr1laN1dbWtkjsBQUFt73uWglKcHAwS5YswcPDg7S0NIKDg7l8+fJNx7iWUF4bIzIykn79+rF69Wq+/fZbJk6cyKeffkrPnj1p0KAB7u7uJCQkkJCQwJtvvomnpydvvfUWiYmJ5OXl8eijjwJXn6mXl1eRGmXAYtm663/huJ1r9eqrV6+matWqFueuzZLf7B7/7HO9fmwbGxv27t1r8QsQYPGvA3fLX43/j+zs7Io8MxERESm77ijBrlWrFra2tuzatQtfX1/gan3w8ePHjRlcDw8PixnnEydOWLzg1rRpU5YtW8ZDDz2Ei4vLTcdq0qQJTZo0ISIigjZt2hAXF0fr1q2pUKEC+fn5t4wzICCAmJgYcnJyjKRy27ZtlCtX7o5m22/m2LFjnD17lujoaHx8fADYs2fPn+rLz88PPz8/Ro4cSd++fVm0aBE9e/bEZDLRvn17Vq5cyeHDh2nXrh2Ojo7k5uayYMECmjdvbtxb06ZN+fnnnylfvjzVq1f/y/cHUK9ePezs7EhLS7MoB7GWXbt2Wezv3LmTOnXqYGNjQ5MmTcjPzycjI4P27dvf8PqAgIAb9nGjNqGhoTdtc6f8/f05c+YMv/zyi1FqlJiY+Jf6FBERkbLljkpEzGYz4eHhjBkzhu+++45Dhw4RFhZGuXL/103nzp2ZN28e33//PXv27OGll16ymBHs378/lStXpnv37mzZsoVTp04RHx/PsGHD+PHHHzl16hQRERHs2LGD06dPs27dOk6cOGHUYVevXp1Tp06xf/9+fv31V3Jzc4vE2b9/f+zt7RkwYACHDh1i06ZNvPLKKzz33HNGUvRX+Pr6UqFCBebOncsPP/zAqlWrmDx58h31cfHiRYYOHUp8fDynT59m27ZtJCYmWtSbBwYGsnTpUho3bozZbKZcuXJ06NCBJUuWWCS9QUFBtGnThh49erBu3TpSU1PZvn07r7322p9O/J2dnRk9ejQjR44kNjaWlJQU9u3bx9y5c4mNjf1TfV4vLS2NUaNGkZyczNKlS5k7dy7Dhw8Hrv7S0b9/f0JDQ/nyyy85deoUu3fvZtq0aaxevRrA+BeO6dOnc+LECebNm2dRfw0wfPhwPvroIxYtWsTx48eZOHEihw8f/ktxd+3alVq1ajFgwAAOHDjAtm3beP311wEsSl5ERETkwXXHq4i88847tG/fnpCQEIKCgmjXrh3NmjUzzs+YMQMfHx/at29Pv379GD16tLHSBYCjoyObN2/G19eXXr16ERAQYCyf5uLigqOjI8eOHeOpp57Cz8+PwYMHM2TIEF588UUAnnrqKbp160anTp3w8PBg6dKlRWJ0dHRk7dq1/Pbbb7Ro0YKnn36aLl26MG/evD/zjIrw8PAgJiaGzz77jHr16hEdHc306dPvqA8bGxvOnj1LaGgofn5+9O7dm8cff9ziZbiOHTuSn59v1FrD1aT7j8dMJhPffPMNHTp04Pnnn8fPz49nn32W06dP/6VfKCZPnsyECROYNm0aAQEBdOvWjdWrV1OjRo0/3ec1oaGhXLx4kZYtWzJkyBCGDx9uvIwJV8uEQkNDefXVV/H396dHjx4kJiYa/3LSunVrFi5cyOzZs2nUqBHr1q0zEt1r+vTpw4QJExg7dizNmjXj9OnT/OMf//hLcdvY2LBixQqys7Np0aIFAwcONFYRKc7ShyIiIlL2mQqt8DV2gYGBNG7cmFmzZlkhJJHSZdu2bbRr146TJ08aK9/cSlZWFq6urviMWE45O8fbthcRS6nRT5R0CCLyALr293dmZuYty5yhDH2To8i98tVXX2E2m6lTpw4nT55k+PDhtG3btljJtYiIiJR9SrBvYMuWLTz++OM3PX/9N0KWVmlpadSrV++m548cOWKUY4il8+fPM27cONLS0qhcuTJBQUHMmDGjpMMSERGR+4RVSkTKmosXL/Lf//73pudr1659D6O5O65cuWLx9fR/VL16dcqX1+9fd4NKRET+GpWIiEhJUInIX+Tg4FAmkuhbKV++fJm/RxEREZGSoARbpIQcigq+7W/AIiIiUvrc8TJ9IiIiIiJyc0qwRURERESsSAm2iIiIiIgVKcEWEREREbEiJdgiIiIiIlakVURESsgjE9dqHewySGs0i4iIZrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgyz0XGBjIiBEjrN5vTEwMbm5ut2wTGRlJ48aNjf2wsDB69Ohh9VhERETkwaVl+uSBNnv2bAoLC0s6DBERESlDlGDLA83V1bWkQxAREZEypkRKRM6fP0///v1xcnLCy8uLd99916Js4OOPP6Z58+Y4Ozvj6elJv379yMjIMK6Pj4/HZDKxevVqGjZsiL29Pa1bt+bQoUPFGv/06dOEhIRQsWJFnJycqF+/Pt98841x/tChQzz++OOYzWaqVKnCc889x6+//mqcz8nJITQ0FLPZjJeXFzNmzChS9mAymVixYoXFuG5ubsTExBj7Z86coXfv3ri5ueHu7k737t1JTU01zl8rX5g+fTpeXl5UqlSJIUOGkJeXZ7TJzc1l3Lhx+Pj4YGdnR+3atfnwww+LfS+3UlBQwLRp06hRowYODg40atSIzz//3Dh/7c9h7dq1NGnSBAcHBzp37kxGRgbffvstAQEBuLi40K9fPy5cuGDR95UrVxg6dCiurq5UrlyZCRMmWMwk5+bmMnr0aKpWrYqTkxOtWrUiPj7eoo+YmBh8fX1xdHSkZ8+enD17tsg9REdHU6VKFZydnQkPD+fSpUsW5/9YIhIYGMiwYcMYO3Ys7u7ueHp6EhkZaXHNsWPHaNeuHfb29tSrV48NGzbc8M9bREREHkwlkmCPGjWKbdu2sWrVKtavX8+WLVvYt2+fcT4vL4/JkyeTlJTEihUrSE1NJSwsrEg/Y8aMYcaMGSQmJuLh4UFISIhF8nkzQ4YMITc3l82bN3Pw4EHeeustzGYzAOfOnaNz5840adKEPXv2sGbNGn755Rd69+5tMW5CQgIrV65k3bp1xMfHW8RfHHl5eQQHB+Ps7MyWLVvYtm0bZrOZbt26cfnyZaPdpk2bSElJYdOmTcTGxhITE2ORpIeGhrJ06VLmzJnD0aNHWbBgwR3dy61MmzaNxYsXM3/+fA4fPszIkSP5+9//TkJCgkW7yMhI5s2bx/bt241fGmbNmkVcXByrV69m3bp1zJ071+Ka2NhYypcvz+7du5k9ezYzZ87kgw8+MM4PHTqUHTt28Omnn3LgwAGeeeYZunXrxokTJwDYtWsX4eHhDB06lP3799OpUyemTJliMcby5cuJjIxk6tSp7NmzBy8vL957773b3ndsbCxOTk7s2rWLt99+m0mTJrF+/XoA8vPz6dGjB46OjuzatYt///vfvPbaa7fsLzc3l6ysLItNREREyi5T4T0uQD1//jyVKlUiLi6Op59+GoDMzEy8vb0ZNGgQs2bNKnLNnj17aNGiBefPn8dsNhMfH0+nTp349NNP6dOnDwC//fYbDz/8MDExMbdNIBs2bMhTTz3FxIkTi5ybMmUKW7ZsYe3atcaxH3/8ER8fH5KTk/H29qZSpUp88sknPPPMMxZjDx482IjfZDLx1VdfWcyOurm5MWvWLMLCwvjkk0+YMmUKR48exWQyAXD58mXc3NxYsWIFjz32GGFhYcTHx5OSkoKNjQ0AvXv3ply5cnz66accP34cf39/1q9fT1BQ0B3fi5+f302fUW5uLu7u7mzYsIE2bdoYxwcOHMiFCxeIi4sz/hw2bNhAly5dgKszxhEREaSkpFCzZk0AXnrpJVJTU1mzZg1wdZY4IyODw4cPG/c+fvx4Vq1axZEjR0hLS6NmzZqkpaXh7e1tjB0UFETLli2ZOnUq/fr1IzMzk9WrVxvnn332WdasWcO5c+cAePTRR2nSpAn/+te/jDatW7fm0qVL7N+/H7g6g33u3Dlj9jkwMJD8/Hy2bNliXNOyZUs6d+5MdHQ0a9asISQkhDNnzuDp6QnAhg0b6Nq1a5E/72siIyOJiooqctxnxHJ9VXoZpK9KFxEpm7KysnB1dSUzMxMXF5dbtr3nM9g//PADeXl5tGzZ0jjm6uqKv7+/sb93715CQkLw9fXF2dmZjh07ApCWlmbR1/WJn7u7O/7+/hw9evS2MQwbNowpU6bQtm1bJk6cyIEDB4xzSUlJbNq0CbPZbGx169YFICUlhZSUFC5fvkyrVq2KjH0nkpKSOHnyJM7OzsY47u7uXLp0iZSUFKNd/fr1jeQawMvLyyiX2b9/PzY2NsbzudEYt7qXWzl58iQXLlyga9euFtcvXry4yLUNGzY0fq5SpQqOjo5Gcn3t2PUlPnA10b2WXMPVP8sTJ06Qn5/PwYMHyc/Px8/Pz2LshIQEY+yjR49a/Blc6+N6xWlzI9ffD1g+8+TkZHx8fIzkGrD4LN9IREQEmZmZxnbmzJnbxiAiIiKl1333kmNOTg7BwcEEBwezZMkSPDw8SEtLIzg42KJ04q8YOHAgwcHBRvnCtGnTmDFjBq+88grZ2dmEhITw1ltvFbnOy8uLkydPFmsMk8lUZHWK68tXsrOzadasGUuWLClyrYeHh/Gzra1tkX4LCgoAcHBwuGUMt7uX210LsHr1aqpWrWpxzs7OzmL/+hhNJtMtYy6O7OxsbGxs2Lt3r8UvF4BR/nI3/dX4/8jOzq7IMxMREZGy654n2DVr1sTW1pbExER8fX2BqyUix48fp0OHDhw7doyzZ88SHR2Nj48PcLVE5EZ27txp9PH7779z/PhxAgICihWHj48PL730Ei+99BIREREsXLiQV155haZNm/LFF19QvXp1ypcv+nhq1aqFra0tu3btKjL29TPJHh4epKenG/snTpyweNGvadOmLFu2jIceeui2/8xwMw0aNKCgoICEhIQblojc7l5upV69etjZ2ZGWlnbTGfK/YteuXRb7O3fupE6dOtjY2NCkSRPy8/PJyMigffv2N7w+ICDghn3cqE1oaOhN29wpf39/zpw5wy+//EKVKlUASExM/Et9ioiISNlyz0tEnJ2dGTBgAGPGjGHTpk0cPnyY8PBwypUrh8lkwtfXlwoVKjB37lx++OEHVq1axeTJk2/Y16RJk9i4cSOHDh0iLCyMypUrF+tLQ0aMGMHatWs5deoU+/btY9OmTUZiPmTIEH777Tf69u1LYmIiKSkprF27lueff578/HzMZjPh4eGMGTOG7777zhi7XDnLR9m5c2fmzZvH999/z549e3jppZcsZkb79+9P5cqV6d69O1u2bOHUqVPEx8czbNgwfvzxx2I9y+rVqzNgwABeeOEFVqxYYfSxfPnyYt3LrTg7OzN69GhGjhxJbGwsKSkp7Nu3j7lz5xIbG1us+G4lLS2NUaNGkZyczNKlS5k7dy7Dhw8HwM/Pj/79+xMaGsqXX37JqVOn2L17N9OmTTNqrocNG8aaNWuYPn06J06cYN68eUaN9zXDhw/no48+YtGiRRw/fpyJEydy+PDhvxR3165dqVWrFgMGDODAgQNs27aN119/HcCi5EVEREQeXCWyisjMmTNp06YNTz75JEFBQbRt25aAgADs7e3x8PAgJiaGzz77jHr16hEdHc306dNv2E90dDTDhw+nWbNm/Pzzz/znP/+hQoUKtx0/Pz+fIUOGEBAQQLdu3fDz8zNWl/D29mbbtm3k5+fz2GOP0aBBA0aMGIGbm5uRRL/zzju0b9+ekJAQgoKCaNeuHc2aNbMYY8aMGfj4+NC+fXv69evH6NGjcXT8vxfaHB0d2bx5M76+vvTq1YuAgABjGbk7mdF+//33efrpp3n55ZepW7cugwYNIicnp9j3ciuTJ09mwoQJTJs2zXhWq1evpkaNGsWO72ZCQ0O5ePEiLVu2ZMiQIQwfPpzBgwcb5xctWkRoaCivvvoq/v7+9OjRw+JfPVq3bs3ChQuZPXs2jRo1Yt26dUaie02fPn2YMGECY8eOpVmzZpw+fZp//OMffyluGxsbVqxYQXZ2Ni1atGDgwIHGKiL29vZ/qW8REREpG+75KiI3kpOTQ9WqVZkxYwbh4eG3bX9t9Yrff//9tl+Nfa8EBgbSuHHjG66CImXbtm3baNeuHSdPnqRWrVq3bX/tLWStIlI2aRUREZGy6U5WESmRlxy///57jh07RsuWLcnMzGTSpEkAdO/evSTCEbkjX331FWazmTp16nDy5EmGDx9O27Zti5Vci4iISNlXIiUiANOnT6dRo0YEBQWRk5PDli1bqFy5slX6vvbNhTfapk6dapUxSru0tLSbPiOz2VxkSUT5P+fPn2fIkCHUrVuXsLAwWrRowcqVK0s6LBEREblP3BclItb23//+l4sXL97wnLu7O+7u7vc4ovvPlStXLL6W/Y/+zMojUjwqESnbVCIiIlI23fclInfbH9dtlqLKly9P7dq1SzoMERERkTKnxEpERERERETKojI5gy1SGhyKCv7TXzIkIiIi9y/NYIuIiIiIWJESbBERERERK1KCLSIiIiJiRUqwRURERESsSC85ipSQRyau1TrYIiIiVnY/fB+BZrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsERERERErUoItIiIiImJFSrBFRERERKxICXYZcf78efr374+TkxNeXl68++67BAYGMmLECAA+/vhjmjdvjrOzM56envTr14+MjAzj+vj4eEwmE6tXr6Zhw4bY29vTunVrDh06VKzxT58+TUhICBUrVsTJyYn69evzzTffGOcPHTrE448/jtlspkqVKjz33HP8+uuvxvmcnBxCQ0Mxm814eXkxY8YMi/gBTCYTK1assBjXzc2NmJgYY//MmTP07t0bNzc33N3d6d69O6mpqcb5sLAwevTowfTp0/Hy8qJSpUoMGTKEvLw8o01ubi7jxo3Dx8cHOzs7ateuzYcffljsexEREZEHmxLsMmLUqFFs27aNVatWsX79erZs2cK+ffuM83l5eUyePJmkpCRWrFhBamoqYWFhRfoZM2YMM2bMIDExEQ8PD0JCQiySz5sZMmQIubm5bN68mYMHD/LWW29hNpsBOHfuHJ07d6ZJkybs2bOHNWvW8Msvv9C7d2+LcRMSEli5ciXr1q0jPj7eIv7iyMvLIzg4GGdnZ7Zs2cK2bdswm81069aNy5cvG+02bdpESkoKmzZtIjY2lpiYGIskPTQ0lKVLlzJnzhyOHj3KggUL7uhe/ig3N5esrCyLTURERMqu8iUdgPx158+fJzY2lri4OLp06QLAokWL8Pb2Ntq88MILxs81a9Zkzpw5tGjRguzsbCN5BJg4cSJdu3YFIDY2locffpivvvrqlgkkQFpaGk899RQNGjQwxrhm3rx5NGnShKlTpxrHPvroI3x8fDh+/Dje3t58+OGHfPLJJ0b818a+E8uWLaOgoIAPPvgAk8lkPAc3Nzfi4+N57LHHAKhYsSLz5s3DxsaGunXr8sQTT7Bx40YGDRrE8ePHWb58OevXrycoKOiO78XPz69IXNOmTSMqKuqO7kVERERKL81glwE//PADeXl5tGzZ0jjm6uqKv7+/sb93715CQkLw9fXF2dmZjh07AlcT4+u1adPG+Nnd3R1/f3+OHj162xiGDRvGlClTaNu2LRMnTuTAgQPGuaSkJDZt2oTZbDa2unXrApCSkkJKSgqXL1+mVatWRca+E0lJSZw8eRJnZ2djHHd3dy5dukRKSorRrn79+tjY2Bj7Xl5eRrnM/v37sbGxMZ7Pjca41b3cSEREBJmZmcZ25syZO7ovERERKV00g/0AyMnJITg4mODgYJYsWYKHhwdpaWkEBwdblE78FQMHDiQ4OJjVq1ezbt06pk2bxowZM3jllVfIzs4mJCSEt956q8h1Xl5enDx5slhjmEwmCgsLLY5dX76SnZ1Ns2bNWLJkSZFrPTw8jJ9tbW2L9FtQUACAg4PDLWO43b3ciJ2dHXZ2drfsV0RERMoOzWCXATVr1sTW1pbExETjWGZmJsePHwfg2LFjnD17lujoaNq3b0/dunUtXnC83s6dO42ff//9d44fP05AQECx4vDx8eGll17iyy+/5NVXX2XhwoUANG3alMOHD1O9enVq165tsTk5OVGrVi1sbW3ZtWtXkbGv5+HhQXp6urF/4sQJLly4YOw3bdqUEydO8NBDDxUZx9XVtVj30KBBAwoKCkhISLjh+dvdi4iIiIgS7DLA2dmZAQMGMGbMGDZt2sThw4cJDw+nXLlymEwmfH19qVChAnPnzuWHH35g1apVTJ48+YZ9TZo0iY0bN3Lo0CHCwsKoXLkyPXr0uG0MI0aMYO3atZw6dYp9+/axadMmIzEfMmQIv/32G3379iUxMZGUlBTWrl3L888/T35+PmazmfDwcMaMGcN3331njF2unOXHs3PnzsybN4/vv/+ePXv28NJLL1nMRvfv35/KlSvTvXt3tmzZwqlTp4iPj2fYsGH8+OOPxXqW1atXZ8CAAbzwwgusWLHC6GP58uXFuhcRERERJdhlxMyZM2nTpg1PPvkkQUFBtG3bloCAAOzt7fHw8CAmJobPPvuMevXqER0dzfTp02/YT3R0NMOHD6dZs2b8/PPP/Oc//6FChQq3HT8/P58hQ4YQEBBAt27d8PPz47333gPA29ubbdu2kZ+fz2OPPUaDBg0YMWIEbm5uRhL9zjvv0L59e0JCQggKCqJdu3Y0a9bMYowZM2bg4+ND+/bt6devH6NHj8bR0dE47+joyObNm/H19aVXr14EBAQQHh7OpUuXcHFxKfazfP/993n66ad5+eWXqVu3LoMGDSInJ6fY9yIiIiIPNlPhH4tapUzIycmhatWqzJgxg/Dw8Nu2j4+Pp1OnTvz++++4ubnd/QCLITAwkMaNGzNr1qySDsWqsrKycHV1xWfEcsrZOd7+AhERESm21Ogn7kq/1/7+zszMvO3EnV5yLCO+//57jh07RsuWLcnMzGTSpEkAdO/evYQjExEREXmw6N+0y5Dp06fTqFEjgoKCyMnJYcuWLVSuXNkqfV/75sIbbdevCS0iIiLyoFOJiBTLf//7Xy5evHjDc+7u7ri7u9/jiEovlYiIiIjcPSoRkVKjatWqJR2CiIiISKmgBFukhByKCr6j1U1ERESkdFANtoiIiIiIFSnBFhERERGxIiXYIiIiIiJWpARbRERERMSKlGCLiIiIiFiRVhERKSGPTFyrdbDlL7tb672KiMifpxlsERERERErUoItIiIiImJFSrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2HLfq169OrNmzSrpMACIiYnBzc2tpMMQERGR+5gSbJGbuJ8SexERESk9lGCLiIiIiFiREuxSZM2aNbRr1w43NzcqVarEk08+SUpKCgCPPvoo48aNs2j/v//9D1tbWzZv3gxAeno6TzzxBA4ODtSoUYO4uLhiz9IWFhYSGRmJr68vdnZ2eHt7M2zYMOP8e++9R506dbC3t6dKlSo8/fTTxrnAwECGDh3K0KFDcXV1pXLlykyYMIHCwsI/9RzOnTvHwIED8fDwwMXFhc6dO5OUlGScj4yMpHHjxnz88cdUr14dV1dXnn32Wc6fP2+0OX/+PP3798fJyQkvLy/effddAgMDGTFihBHz6dOnGTlyJCaTCZPJZBHD2rVrCQgIwGw2061bN9LT0//UvYiIiEjZowS7FMnJyWHUqFHs2bOHjRs3Uq5cOXr27ElBQQH9+/fn008/tUhaly1bhre3N+3btwcgNDSUn376ifj4eL744gv+/e9/k5GRUayxv/jiC959910WLFjAiRMnWLFiBQ0aNABgz549DBs2jEmTJpGcnMyaNWvo0KGDxfWxsbGUL1+e3bt3M3v2bGbOnMkHH3zwp57DM888Q0ZGBt9++y179+6ladOmdOnShd9++81ok5KSwooVK/j666/5+uuvSUhIIDo62jg/atQotm3bxqpVq1i/fj1btmxh3759xvkvv/yShx9+mEmTJpGenm6RQF+4cIHp06fz8ccfs3nzZtLS0hg9evRN483NzSUrK8tiExERkbJLX5Veijz11FMW+x999BEeHh4cOXKE3r17M2LECLZu3Wok1HFxcfTt2xeTycSxY8fYsGEDiYmJNG/eHIAPPviAOnXqFGvstLQ0PD09CQoKwtbWFl9fX1q2bGmcc3Jy4sknn8TZ2Zlq1arRpEkTi+t9fHx49913MZlM+Pv7c/DgQd59910GDRp0R89g69at7N69m4yMDOzs7ACYPn06K1as4PPPP2fw4MEAFBQUEBMTg7OzMwDPPfccGzdu5M033+T8+fPExsYSFxdHly5dAFi0aBHe3t7GOO7u7tjY2ODs7Iynp6dFDHl5ecyfP59atWoBMHToUCZNmnTTmKdNm0ZUVNQd3aeIiIiUXprBLkVOnDhB3759qVmzJi4uLlSvXh24muB6eHjw2GOPsWTJEgBOnTrFjh076N+/PwDJycmUL1+epk2bGv3Vrl2bihUrFmvsZ555hosXL1KzZk0GDRrEV199xZUrVwDo2rUr1apVo2bNmjz33HMsWbKECxcuWFzfunVrizKLNm3acOLECfLz8+/oGSQlJZGdnU2lSpUwm83GdurUKaNcBq6+oHgtuQbw8vIyZut/+OEH8vLyjF8QAFxdXfH39y9WDI6OjkZy/ce+byQiIoLMzExjO3PmTLHvV0REREofJdilSEhICL/99hsLFy5k165d7Nq1C4DLly8D0L9/fz7//HPy8vKIi4ujQYMGRhnHX+Xj40NycjLvvfceDg4OvPzyy3To0IG8vDycnZ3Zt28fS5cuxcvLizfeeINGjRpx7tw5q4x9vezsbLy8vNi/f7/FlpyczJgxY4x2tra2FteZTCYKCgqsEsON+r5VPbmdnR0uLi4Wm4iIiJRdSrBLibNnz5KcnMzrr79Oly5dCAgI4Pfff7do0717dy5dusSaNWuIi4szZq8B/P39uXLlCt9//71x7OTJk0X6uBUHBwdCQkKYM2cO8fHx7Nixg4MHDwJQvnx5goKCePvttzlw4ACpqal89913xrXXfhm4ZufOndSpUwcbG5s7eg5Nmzbl559/pnz58tSuXdtiq1y5crH6qFmzJra2tiQmJhrHMjMzOX78uEW7ChUq3PEMu4iIiIhqsEuJihUrUqlSJf7973/j5eVFWloa48ePt2jj5OREjx49mDBhAkePHqVv377Gubp16xIUFMTgwYN5//33sbW15dVXX8XBwaHIChk3EhMTQ35+Pq1atcLR0ZFPPvkEBwcHqlWrxtdff80PP/xAhw4dqFixIt988w0FBQUWJRdpaWmMGjWKF198kX379jF37lxmzJhxx88hKCiINm3a0KNHD95++238/Pz46aefWL16NT179jTqy2/F2dmZAQMGMGbMGNzd3XnooYeYOHEi5cqVs3gW1atXZ/PmzTz77LPY2dkVO4EXERGRB5tmsEuJcuXK8emnn7J3714eeeQRRo4cyTvvvFOkXf/+/UlKSqJ9+/b4+vpanFu8eDFVqlShQ4cO9OzZk0GDBuHs7Iy9vf1tx3dzc2PhwoW0bduWhg0bsmHDBv7zn/9QqVIl3Nzc+PLLL+ncuTMBAQHMnz+fpUuXUr9+feP60NBQLl68SMuWLRkyZAjDhw83Xki8EyaTiW+++YYOHTrw/PPP4+fnx7PPPsvp06epUqVKsfuZOXMmbdq04cknnyQoKIi2bdsSEBBg8SwmTZpEamoqtWrVwsPD445jFRERkQeTqfDPLkYspd6PP/6Ij48PGzZsMFbTuBsCAwNp3Ljxff2tiDk5OVStWpUZM2YQHh5+V8fKysrC1dUVnxHLKWfneFfHkrIvNfqJkg5BROSBcO3v78zMzNu+T6USkQfId999R3Z2Ng0aNCA9PZ2xY8dSvXr1ImtWPwi+//57jh07RsuWLcnMzDSW2evevXsJRyYiIiKlnUpEHiB5eXn885//pH79+vTs2RMPDw/i4+OxtbVlyZIlFsveXb9dX+phbVu2bLnpuGaz+a6NC1fXz27UqBFBQUHk5OSwZcsW1VmLiIjIX6YSEQGufnX4L7/8csNztra2VKtW7a6Me/HiRf773//e9Hzt2rXvyrglSSUiYk0qERERuTdUIiJ3zNnZ2eKLWe4VBweHMplEi4iIyINLJSIiIiIiIlakGWyREnIoKljf6igiIlIGaQZbRERERMSKlGCLiIiIiFiREmwREREREStSgi0iIiIiYkV6yVGkhDwyca3WwRYpIVo/XETuJs1gi4iIiIhYkRJsERERERErUoItIiIiImJFSrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CJ3KDAwkBEjRpR0GCIiInKfUoItIiIiImJFSrDlgXD58uWSDkFEREQeEEqw5Y4FBgYydOhQhg4diqurK5UrV2bChAkUFhYC8PHHH9O8eXOcnZ3x9PSkX79+ZGRkWPSxatUq6tSpg729PZ06dSI2NhaTycS5c+eMNlu3bqV9+/Y4ODjg4+PDsGHDyMnJKVaM1atXZ/LkyYSGhuLi4sLgwYMBGDduHH5+fjg6OlKzZk0mTJhAXl6ecV1kZCSNGzfm448/pnr16ri6uvLss89y/vz5m461evVqXF1dWbJkSXEfoYiIiJRhSrDlT4mNjaV8+fLs3r2b2bNnM3PmTD744AMA8vLymDx5MklJSaxYsYLU1FTCwsKMa0+dOsXTTz9Njx49SEpK4sUXX+S1116z6D8lJYVu3brx1FNPceDAAZYtW8bWrVsZOnRosWOcPn06jRo14vvvv2fChAkAODs7ExMTw5EjR5g9ezYLFy7k3XffLTL2ihUr+Prrr/n6669JSEggOjr6hmPExcXRt29flixZQv/+/W/YJjc3l6ysLItNREREyi5T4bVpR5FiCgwMJCMjg8OHD2MymQAYP348q1at4siRI0Xa79mzhxYtWnD+/HnMZjPjx49n9erVHDx40Gjz+uuv8+abb/L777/j5ubGwIEDsbGxYcGCBUabrVu30rFjR3JycrC3t79ljNWrV6dJkyZ89dVXt2w3ffp0Pv30U/bs2QNcncF+5513+Pnnn3F2dgZg7NixbN68mZ07dxr337hxY+rUqcNrr73GypUr6dix403HiIyMJCoqqshxnxHLKWfneMv4ROTuSI1+oqRDEJFSJisrC1dXVzIzM3FxcbllW81gy5/SunVrI7kGaNOmDSdOnCA/P5+9e/cSEhKCr68vzs7ORvKZlpYGQHJyMi1atLDor2XLlhb7SUlJxMTEYDabjS04OJiCggJOnTpVrBibN29e5NiyZcto27Ytnp6emM1mXn/9dSOua6pXr24k1wBeXl5FSlw+//xzRo4cyfr162+ZXANERESQmZlpbGfOnClW/CIiIlI6KcEWq7p06RLBwcG4uLiwZMkSEhMTjVnkO3nRMDs7mxdffJH9+/cbW1JSEidOnKBWrVrF6sPJyclif8eOHfTv35//9//+H19//TXff/89r732WpG4bG1tLfZNJhMFBQUWx5o0aYKHhwcfffQRt/tHIDs7O1xcXCw2ERERKbvKl3QAUjrt2rXLYn/nzp3UqVOHY8eOcfbsWaKjo/Hx8QEwyi+u8ff355tvvrE4lpiYaLHftGlTjhw5Qu3ata0W8/bt26lWrZpFvffp06f/VF+1atVixowZBAYGYmNjw7x586wVpoiIiJRymsGWPyUtLY1Ro0aRnJzM0qVLmTt3LsOHD8fX15cKFSowd+5cfvjhB1atWsXkyZMtrn3xxRc5duwY48aN4/jx4yxfvpyYmBgAo+xk3LhxbN++naFDh7J//35OnDjBypUr7+glxz+qU6cOaWlpfPrpp6SkpDBnzpzb1mjfip+fH5s2beKLL77QF8+IiIiIQQm2/CmhoaFcvHiRli1bMmTIEIYPH87gwYPx8PAgJiaGzz77jHr16hEdHc306dMtrq1Rowaff/45X375JQ0bNuT99983ZpXt7OwAaNiwIQkJCRw/fpz27dvTpEkT3njjDby9vf90zH/7298YOXIkQ4cOpXHjxmzfvt1YXeTP8vf357vvvmPp0qW8+uqrf6kvERERKRu0iojcsWuraMyaNctqfb755pvMnz//gXgB8NpbyFpFRKTkaBUREblTd7KKiGqwpUS89957tGjRgkqVKrFt2zbeeeedv1T+ISIiInK/UIItJeLEiRNMmTKF3377DV9fX1599VUiIiKKde2WLVt4/PHHb3o+OzvbWmGKiIiI3DGViEipc/HiRf773//e9Lw1Vx65G1QiIlLyVCIiIndKJSJSpjk4ONz3SbSIiIg8uJRgi5SQQ1HB+tIZERGRMkjL9ImIiIiIWJESbBERERERK1KCLSIiIiJiRUqwRURERESsSAm2iIiIiIgVaRURkRLyyMS1Wgf7D7Q2sYiIlAWawRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsERERERErUoJdigUGBjJixIiSDqPUCgsLo0ePHsa+nqeIiIhYgxLsB1R8fDwmk4lz586VdCjFFhkZSePGje9a/19++SWTJ0829qtXr86sWbPu2ngiIiJSNmkdbClz8vLysLW1vePr3N3d70I0IiIi8qDRDHYZsnr1alxdXVmyZAkff/wxzZs3x9nZGU9PT/r160dGRgYAqampdOrUCYCKFStiMpkICwsjNTUVk8lUZAsMDCzW+Nu2bSMwMBBHR0cqVqxIcHAwv//+OwAFBQVMmzaNGjVq4ODgQKNGjfj888+Na6/NqG/cuJHmzZvj6OjIo48+SnJyMgAxMTFERUWRlJRkxBUTEwOAyWTi/fff529/+xtOTk68+eab5OfnEx4ebozn7+/P7Nmzbxn/9SUigYGBnD59mpEjRxrj5eTk4OLiYhE3wIoVK3BycuL8+fPFek4iIiJStinBLiPi4uLo27cvS5YsoX///uTl5TF58mSSkpJYsWIFqamphIWFAeDj48MXX3wBQHJyMunp6cyePRsfHx/S09ON7fvvv6dSpUp06NDhtuPv37+fLl26UK9ePXbs2MHWrVsJCQkhPz8fgGnTprF48WLmz5/P4cOHGTlyJH//+99JSEiw6Oe1115jxowZ7Nmzh/Lly/PCCy8A0KdPH1599VXq169vxNenTx/jusjISHr27MnBgwd54YUXKCgo4OGHH+azzz7jyJEjvPHGG/zzn/9k+fLlxXqeX375JQ8//DCTJk0yxnNycuLZZ59l0aJFFm0XLVrE008/jbOz8w37ys3NJSsry2ITERGRskslImXAv/71L1577TX+85//0LFjRwAjMQWoWbMmc+bMoUWLFmRnZ2M2m41yiIceegg3NzejraenJwCXLl2iR48etGnThsjIyNvG8Pbbb9O8eXPee+8941j9+vWBqwnm1KlT2bBhA23atDFi2rp1KwsWLDBiBnjzzTeN/fHjx/PEE09w6dIlHBwcMJvNlC9f3ojxev369eP555+3OBYVFWX8XKNGDXbs2MHy5cvp3bv3be/H3d0dGxsb418Arhk4cCCPPvoo6enpeHl5kZGRwTfffMOGDRtu2te0adMsYhEREZGyTTPYpdznn3/OyJEjWb9+vUWiunfvXkJCQvD19cXZ2dk4l5aWVqx+X3jhBc6fP09cXBzlyt3+Y3JtBvtGTp48yYULF+jatStms9nYFi9eTEpKikXbhg0bGj97eXkBGKUtt9K8efMix/71r3/RrFkzPDw8MJvN/Pvf/y72/d9My5YtqV+/PrGxsQB88sknVKtW7Zaz/BEREWRmZhrbmTNn/lIMIiIicn/TDHYp16RJE/bt28dHH31E8+bNjVrh4OBggoODWbJkCR4eHqSlpREcHMzly5dv2+eUKVNYu3Ytu3fvvmnZwx85ODjc9Fx2djZwtUa8atWqFufs7Ows9q9/OdFkMgFX67dvx8nJyWL/008/ZfTo0cyYMYM2bdrg7OzMO++8w65du27b1+0MHDiQf/3rX4wfP55Fixbx/PPPG7HeiJ2dXZH7FBERkbJLM9ilXK1atdi0aRMrV67klVdeAeDYsWOcPXuW6Oho2rdvT926dYvMAleoUAHAqJG+5osvvmDSpEksX76cWrVqFTuOhg0bsnHjxhueq1evHnZ2dqSlpVG7dm2LzcfHp9hjVKhQoUi8N7Nt2zYeffRRXn75ZZo0aULt2rWLzJb/2fH+/ve/c/r0aebMmcORI0cYMGDAHfUrIiIiZZsS7DLAz8+PTZs28cUXXzBixAh8fX2pUKECc+fO5YcffmDVqlUW6zsDVKtWDZPJxNdff83//vc/srOzOXToEKGhoYwbN4769evz888/8/PPP/Pbb7/dNoaIiAgSExN5+eWXOXDgAMeOHeP999/n119/xdnZmdGjRzNy5EhiY2NJSUlh3759zJ071yi1KI7q1atz6tQp9u/fz6+//kpubu5N29apU4c9e/awdu1ajh8/zoQJE0hMTCz2WNfG27x5M//973/59ddfjeMVK1akV69ejBkzhscee4yHH374jvoVERGRsk0Jdhnh7+/Pd999x9KlS4mOjiYmJobPPvuMevXqER0dzfTp0y3aV61alaioKMaPH0+VKlUYOnQoe/bs4cKFC0yZMgUvLy9j69Wr123H9/PzY926dSQlJdGyZUvatGnDypUrKV/+ahXS5MmTmTBhAtOmTSMgIIBu3bqxevVqatSoUex7fOqpp+jWrRudOnXCw8ODpUuX3rTtiy++SK9evejTpw+tWrXi7NmzvPzyy8UeC2DSpEmkpqZSq1YtPDw8LM6Fh4dz+fJli5dJRURERABMhYWFhSUdhEhp8/HHHzNy5Eh++ukno9ymuLKysnB1dcVnxHLK2TnepQhLp9ToJ0o6BBERkRu69vd3ZmYmLi4ut2yrlxxF7sCFCxdIT08nOjqaF1988Y6TaxERESn7VCIixfL4449bLLF3/TZ16tSSDu+eefvtt6lbty6enp5ERESUdDgiIiJyH1KJiBTLf//7Xy5evHjDc+7u7sYX18jtqUTk5lQiIiIi9yuViIjV/XH9ahERERG5MZWIiIiIiIhYkWawRUrIoajg2/4Tk4iIiJQ+msEWEREREbEiJdgiIiIiIlakBFtERERExIqUYIuIiIiIWJFechQpIY9MXGuxDrbWgBYRESkbNIMtIiIiImJFSrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgy30vMDCQESNG3NE1qampmEwm9u/ff9M28fHxmEwmzp0795fiExEREbme1sGWMsnHx4f09HQqV65c0qGIiIjIA0YJtpQ5ly9fpkKFCnh6epZ0KCIiIvIAUomIlApXrlxh6NChuLq6UrlyZSZMmEBhYSEA1atXZ/LkyYSGhuLi4sLgwYNvWCLyzTff4Ofnh4ODA506dSI1NbXIOAsXLsTHxwdHR0d69uzJzJkzcXNzs2izcuVKmjZtir29PTVr1iQqKoorV67cxbsXERGR0kQJtpQKsbGxlC9fnt27dzN79mxmzpzJBx98YJyfPn06jRo14vvvv2fChAlFrj9z5gy9evUiJCSE/fv3M3DgQMaPH2/RZtu2bbz00ksMHz6c/fv307VrV958802LNlu2bCE0NJThw4dz5MgRFixYQExMTJF218vNzSUrK8tiExERkbLLVHhtGlDkPhUYGEhGRgaHDx/GZDIBMH78eFatWsWRI0eoXr06TZo04auvvjKuSU1NpUaNGnz//fc0btyYf/7zn6xcuZLDhw8bbcaPH89bb73F77//jpubG88++yzZ2dl8/fXXRpu///3vfP3118aLkEFBQXTp0oWIiAijzSeffMLYsWP56aefbhh/ZGQkUVFRRY77jFhOOTvH/4s5+ok/94BERETkrsvKysLV1ZXMzExcXFxu2VYz2FIqtG7d2kiuAdq0acOJEyfIz88HoHnz5re8/ujRo7Rq1criWJs2bSz2k5OTadmypcWxP+4nJSUxadIkzGazsQ0aNIj09HQuXLhww7EjIiLIzMw0tjNnztz6ZkVERKRU00uOUiY4OTndk3Gys7OJioqiV69eRc7Z29vf8Bo7Ozvs7OzudmgiIiJyn1CCLaXCrl27LPZ37txJnTp1sLGxKdb1AQEBrFq1qkgf1/P39ycxMdHi2B/3mzZtSnJyMrVr1y5u6CIiIvKAUYmIlAppaWmMGjWK5ORkli5dyty5cxk+fHixr3/ppZc4ceIEY8aMITk5mbi4OGJiYizavPLKK3zzzTfMnDmTEydOsGDBAr799luL0pQ33niDxYsXExUVxeHDhzl69Ciffvopr7/+urVuVUREREo5JdhSKoSGhnLx4kVatmzJkCFDGD58OIMHDy729b6+vnzxxResWLGCRo0aMX/+fKZOnWrRpm3btsyfP5+ZM2fSqFEj1qxZw8iRIy1KP4KDg/n6669Zt24dLVq0oHXr1rz77rtUq1bNavcqIiIipZtWERG5hUGDBnHs2DG2bNlitT6vvYWsVURERERKjztZRUQ12CLXmT59Ol27dsXJyYlvv/2W2NhY3nvvvZIOS0REREoRJdgi19m9ezdvv/0258+fp2bNmsyZM4eBAweWdFgiIiJSiijBFrnO8uXLSzoEERERKeX0kqOIiIiIiBVpBlukhByKCr7tSxIiIiJS+mgGW0RERETEipRgi4iIiIhYkRJsERERERErUoItIiIiImJFSrBFRERERKxIq4iIlJBHJq61+Kr0+42+ul1EROTP0Qy2iIiIiIgVKcEWEREREbEiJdgiIiIiIlakBFtERERExIqUYIuIiIiIWJESbJHbiI+Px2Qyce7cuZIORUREREoBJdgiIiIiIlakBFtERERExIqUYEuZUVBQwNtvv03t2rWxs7PD19eXN998k86dOzN06FCLtv/73/+oUKECGzduBCA3N5dx48bh4+ODnZ0dtWvX5sMPP7zpWFu3bqV9+/Y4ODjg4+PDsGHDyMnJuav3JyIiIqWDEmwpMyIiIoiOjmbChAkcOXKEuLg4qlSpwsCBA4mLiyM3N9do+8knn1C1alU6d+4MQGhoKEuXLmXOnDkcPXqUBQsWYDabbzhOSkoK3bp146mnnuLAgQMsW7aMrVu3Fknir8nNzSUrK8tiExERkbLLVFhYWFjSQYj8VefPn8fDw4N58+YxcOBAi3OXLl3C29ub+fPn07t3bwAaNWpEr169mDhxIsePH8ff35/169cTFBRUpO/4+Hg6derE77//jpubGwMHDsTGxoYFCxYYbbZu3UrHjh3JycnB3t7e4vrIyEiioqKK9OszYrm+Kl1ERKSUyMrKwtXVlczMTFxcXG7ZVjPYUiYcPXqU3NxcunTpUuScvb09zz33HB999BEA+/bt49ChQ4SFhQGwf/9+bGxs6NixY7HGSkpKIiYmBrPZbGzBwcEUFBRw6tSpIu0jIiLIzMw0tjNnzvz5GxUREZH7XvmSDkDEGhwcHG55fuDAgTRu3Jgff/yRRYsW0blzZ6pVq1asa/8oOzubF198kWHDhhU55+vrW+SYnZ0ddnZ2dzSGiIiIlF6awZYyoU6dOjg4OBgvLf5RgwYNaN68OQsXLiQuLo4XXnjB4lxBQQEJCQnFGqtp06YcOXKE2rVrF9kqVKhglfsRERGR0ksJtpQJ9vb2jBs3jrFjx7J48WJSUlLYuXOnxUogAwcOJDo6msLCQnr27Gkcr169OgMGDOCFF15gxYoVnDp1ivj4eJYvX37DscaNG8f27dsZOnQo+/fv58SJE6xcufKmLzmKiIjIg0UJtpQZEyZM4NVXX+WNN94gICCAPn36kJGRYZzv27cv5cuXp2/fvkVeRHz//fd5+umnefnll6lbty6DBg266bJ7DRs2JCEhgePHj9O+fXuaNGnCG2+8gbe39129PxERESkdtIqIPDBSU1OpVasWiYmJNG3atMTiuPYWslYRERERKT3uZBURveQoZV5eXh5nz57l9ddfp3Xr1iWaXIuIiEjZpxIRKfO2bduGl5cXiYmJzJ8/v6TDERERkTJOM9hS5gUGBqJKKBEREblXNIMtIiIiImJFSrBFRERERKxIJSIiJeRQVPBt30IWERGR0kcz2CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsEREREREr0kuOIiXkkYlr75uvStfXoouIiFiPZrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgy30vMDCQESNG3JOxIiMjady48T0ZS0RERMomJdgi1xk9ejQbN2409sPCwujRo0fJBSQiIiKljtbBFrmO2WzGbDaXdBgiIiJSimkGW+4rOTk5hIaGYjab8fLyYsaMGRbnc3NzGT16NFWrVsXJyYlWrVoRHx9vnI+JicHNzY21a9cSEBCA2WymW7dupKenG23i4+Np2bIlTk5OuLm50bZtW06fPg1YlohERkYSGxvLypUrMZlMmEwm4uPj6dy5M0OHDrWI63//+x8VKlSwmP0WERGRB5MSbLmvjBkzhoSEBFauXMm6deuIj49n3759xvmhQ4eyY8cOPv30Uw4cOMAzzzxDt27dOHHihNHmwoULTJ8+nY8//pjNmzeTlpbG6NGjAbhy5Qo9evSgY8eOHDhwgB07djB48GBMJlORWEaPHk3v3r2NBD09PZ1HH32UgQMHEhcXR25urtH2k08+oWrVqnTu3PkuPh0REREpDVQiIveN7OxsPvzwQz755BO6dOkCQGxsLA8//DAAaWlpLFq0iLS0NLy9vYGrSfCaNWtYtGgRU6dOBSAvL4/58+dTq1Yt4GpSPmnSJACysrLIzMzkySefNM4HBATcMB6z2YyDgwO5ubl4enoax3v16sXQoUNZuXIlvXv3Bq7OnIeFhd0wUc/NzbVIxrOysv78QxIREZH7nmaw5b6RkpLC5cuXadWqlXHM3d0df39/AA4ePEh+fj5+fn5GrbTZbCYhIYGUlBTjGkdHRyN5BvDy8iIjI8PoLywsjODgYEJCQpg9e7ZF+Uhx2Nvb89xzz/HRRx8BsG/fPg4dOkRYWNgN20+bNg1XV1dj8/HxuaPxREREpHRRgi2lRnZ2NjY2Nuzdu5f9+/cb29GjR5k9e7bRztbW1uI6k8lEYWGhsb9o0SJ27NjBo48+yrJly/Dz82Pnzp13FMvAgQNZv349P/74I4sWLaJz585Uq1bthm0jIiLIzMw0tjNnztzRWCIiIlK6KMGW+0atWrWwtbVl165dxrHff/+d48ePA9CkSRPy8/PJyMigdu3aFtv1JRzF0aRJEyIiIti+fTuPPPIIcXFxN2xXoUIF8vPzixxv0KABzZs3Z+HChcTFxfHCCy/cdCw7OztcXFwsNhERESm7lGDLfcNsNhMeHs6YMWP47rvvjLKLcuWufkz9/Pzo378/oaGhfPnll5w6dYrdu3czbdo0Vq9eXawxTp06RUREBDt27OD06dOsW7eOEydO3LQOu3r16hw4cIDk5GR+/fVX8vLyjHMDBw4kOjqawsJCevbs+dcfgIiIiJQJSrDlvvLOO+/Qvn17QkJCCAoKol27djRr1sw4v2jRIkJDQ3n11Vfx9/enR48eJCYm4uvrW6z+HR0dOXbsGE899RR+fn4MHjyYIUOG8OKLL96w/aBBg/D396d58+Z4eHiwbds241zfvn0pX748ffv2xd7e/q/duIiIiJQZpsLri1NFpNhSU1OpVasWiYmJNG3atNjXZWVlXX3ZccRyytk53sUIiy81+omSDkFEROS+du3v78zMzNuWe2qZPpE7lJeXx9mzZ3n99ddp3br1HSXXIiIiUvapRETkDm3btg0vLy8SExOZP39+SYcjIiIi9xnNYIvcocDAQFRZJSIiIjejGWwREREREStSgi0iIiIiYkUqEREpIYeigvWlMyIiImWQZrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEirSKiEgJeWTiWsrZOZZ0GLeUGv1ESYcgIiJS6mgGW0RERETEipRgi4iIiIhYkRJsERERERErUoItIiIiImJFSrBFRERERKxICbaUafHx8ZhMJs6dO1fSoYiIiMgDQgm2iIiIiIgVKcEWEREREbEiJdhyQ4GBgQwbNoyxY8fi7u6Op6cnkZGRAKSmpmIymdi/f7/R/ty5c5hMJuLj44H/K81Yu3YtTZo0wcHBgc6dO5ORkcG3335LQEAALi4u9OvXjwsXLhQrpoKCAqZNm0aNGjVwcHCgUaNGfP755xZtvvnmG/z8/HBwcKBTp06kpqYW6WfhwoX4+Pjg6OhIz549mTlzJm5ubhZtVq5cSdOmTbG3t6dmzZpERUVx5coVAAoLC4mMjMTX1xc7Ozu8vb0ZNmxYse5BREREyj59k6PcVGxsLKNGjWLXrl3s2LGDsLAw2rZtS506dYrdR2RkJPPmzcPR0ZHevXvTu3dv7OzsiIuLIzs7m549ezJ37lzGjRt3276mTZvGJ598wvz586lTpw6bN2/m73//Ox4eHnTs2JEzZ87Qq1cvhgwZwuDBg9mzZw+vvvqqRR/btm3jpZde4q233uJvf/sbGzZsYMKECRZttmzZQmhoKHPmzKF9+/akpKQwePBgACZOnMgXX3zBu+++y6effkr9+vX5+eefSUpKumncubm55ObmGvtZWVnFfn4iIiJS+ijBlptq2LAhEydOBKBOnTrMmzePjRs33lGCPWXKFNq2bQtAeHg4ERERpKSkULNmTQCefvppNm3adNsEOzc3l6lTp7JhwwbatGkDQM2aNdm6dSsLFiygY8eOvP/++9SqVYsZM2YA4O/vz8GDB3nrrbeMfubOncvjjz/O6NGjAfDz82P79u18/fXXRpuoqCjGjx/PgAEDjHEmT57M2LFjmThxImlpaXh6ehIUFIStrS2+vr60bNnyprFPmzaNqKioYj8zERERKd1UIiI31bBhQ4t9Ly8vMjIy/nQfVapUwdHR0Uiurx0rTp8nT57kwoULdO3aFbPZbGyLFy8mJSUFgKNHj9KqVSuL664l49ckJycXSYb/uJ+UlMSkSZMsxhk0aBDp6elcuHCBZ555hosXL1KzZk0GDRrEV199ZZSP3EhERASZmZnGdubMmdver4iIiJRemsGWm7K1tbXYN5lMFBQUUK7c1d/LCgsLjXN5eXm37cNkMt20z9vJzs4GYPXq1VStWtXinJ2d3W2vvxPZ2dlERUXRq1evIufs7e3x8fEhOTmZDRs2sH79el5++WXeeecdEhISitzftfisHaOIiIjcv5Rgyx3z8PAAID09nSZNmgBYvPB4N9SrVw87OzvS0tLo2LHjDdsEBASwatUqi2M7d+602Pf39ycxMdHi2B/3mzZtSnJyMrVr175pPA4ODoSEhBASEsKQIUOoW7cuBw8epGnTpndyWyIiIlIGKcGWO+bg4EDr1q2Jjo6mRo0aZGRk8Prrr9/VMZ2dnRk9ejQjR46koKCAdu3akZmZybZt23BxcWHAgAG89NJLzJgxgzFjxjBw4ED27t1LTEyMRT+vvPIKHTp0YObMmYSEhPDdd9/x7bffYjKZjDZvvPEGTz75JL6+vjz99NOUK1eOpKQkDh06xJQpU4iJiSE/P59WrVrh6OjIJ598goODA9WqVburz0BERERKB9Vgy5/y0UcfceXKFZo1a8aIESOYMmXKXR9z8uTJTJgwgWnTphEQEEC3bt1YvXo1NWrUAMDX15cvvviCFStW0KhRI+bPn8/UqVMt+mjbti3z589n5syZNGrUiDVr1jBy5Ejs7e2NNsHBwXz99desW7eOFi1a0Lp1a959910jgXZzc2PhwoW0bduWhg0bsmHDBv7zn/9QqVKlu/4MRERE5P5nKry+kFbkATRo0CCOHTvGli1b7sl4WVlZuLq64jNiOeXsHO/JmH9WavQTJR2CiIjIfeHa39+ZmZm4uLjcsq1KROSBM336dLp27YqTkxPffvstsbGxvPfeeyUdloiIiJQRSrDlvpCWlka9evVuev7IkSP4+vpaZazdu3fz9ttvc/78eWrWrMmcOXMYOHCgVfoWERERUYIt9wVvb+9brkTi7e1ttbGWL19utb5ERERE/kgJttwXypcvf8tl8URERERKC60iIiIiIiJiRZrBFikhh6KCb/sWsoiIiJQ+msEWEREREbEiJdgiIiIiIlakBFtERERExIqUYIuIiIiIWJFechQpIY9MXHvffVW6vhpdRETkr9MMtoiIiIiIFSnBFhERERGxIiXYIiIiIiJWpARbRERERMSKlGCLiIiIiFiREmwREREREStSgi0PvMjISBo3blzSYYiIiEgZoQRbRERERMSKlGCLiIiIiFiREmy5ocDAQIYNG8bYsWNxd3fH09OTyMhIAFJTUzGZTOzfv99of+7cOUwmE/Hx8QDEx8djMplYu3YtTZo0wcHBgc6dO5ORkcG3335LQEAALi4u9OvXjwsXLvzlmK5JS0uje/fumM1mXFxc6N27N7/88otFm+joaKpUqYKzszPh4eFcunSpyFgffPABAQEB2NvbU7duXd577z3j3OXLlxk6dCheXl7Y29tTrVo1pk2bVqx7EBERkbJPCbbcVGxsLE5OTuzatYu3336bSZMmsX79+jvqIzIyknnz5rF9+3bOnDlD7969mTVrFnFxcaxevZp169Yxd+5cq8RUUFBA9+7d+e2330hISGD9+vX88MMP9OnTx7h++fLlREZGMnXqVPbs2YOXl5dF8gywZMkS3njjDd58802OHj3K1KlTmTBhArGxsQDMmTOHVatWsXz5cpKTk1myZAnVq1e/acy5ublkZWVZbCIiIlJ2lS/pAOT+1bBhQyZOnAhAnTp1mDdvHhs3bqROnTrF7mPKlCm0bdsWgPDwcCIiIkhJSaFmzZoAPP3002zatIlx48b9pZi6du3Kxo0bOXjwIKdOncLHxweAxYsXU79+fRITE2nRogWzZs0iPDyc8PBwI74NGzZYzGJPnDiRGTNm0KtXLwBq1KjBkSNHWLBgAQMGDCAtLY06derQrl07TCYT1apVu2XM06ZNIyoqqtjPTEREREo3zWDLTTVs2NBi38vLi4yMjD/dR5UqVXB0dDSS62vH7qTPW8V09OhRfHx8jOQaoF69eri5uXH06FGjTatWrSz6aNOmjfFzTk4OKSkphIeHYzabjW3KlCmkpKQAEBYWxv79+/H392fYsGGsW7fuljFHRESQmZlpbGfOnCn2/YqIiEjpoxlsuSlbW1uLfZPJREFBAeXKXf29rLCw0DiXl5d32z5MJtNN+/yrMVlLdnY2AAsXLiySiNvY2ADQtGlTTp06xbfffsuGDRvo3bs3QUFBfP755zfs087ODjs7O6vFKCIiIvc3zWDLHfPw8AAgPT3dOHb9C48lJSAggDNnzljMEB85coRz585Rr149o82uXbssrtu5c6fxc5UqVfD29uaHH36gdu3aFluNGjWMdi4uLvTp04eFCxeybNkyvvjiC3777be7fIciIiJSGmgGW+6Yg4MDrVu3Jjo6mho1apCRkcHrr79e0mERFBREgwYN6N+/P7NmzeLKlSu8/PLLdOzYkebNmwMwfPhwwsLCaN68OW3btmXJkiUcPnzYomwlKiqKYcOG4erqSrdu3cjNzWXPnj38/vvvjBo1ipkzZ+Ll5UWTJk0oV64cn332GZ6enri5uZXQnYuIiMj9RDPY8qd89NFHXLlyhWbNmjFixAimTJlS0iFhMplYuXIlFStWpEOHDgQFBVGzZk2WLVtmtOnTpw8TJkxg7NixNGvWjNOnT/OPf/zDop+BAwfywQcfsGjRIho0aEDHjh2JiYkxZrCdnZ15++23ad68OS1atCA1NZVvvvnGKJ0RERGRB5up8PpCWhG567KysnB1dcVnxHLK2TmWdDgWUqOfKOkQRERE7kvX/v7OzMzExcXllm015SYiIiIiYkVKsOW+kJaWZrEs3h+3tLS0kg5RREREpFj0kqPcF7y9vW+5Eom3t/e9C0ZERETkL1CCLfeF8uXLU7t27ZIOQ0REROQvU4ItUkIORQXf9iUJERERKX1Ugy0iIiIiYkVKsEVERERErEgJtoiIiIiIFSnBFhERERGxIiXYIiIiIiJWpFVERErIIxPX3ndflS4iItaTGv1ESYcgJUQz2CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsERERERErUoItIiIiImJFSrDlpkwmEytWrCjpMERERERKFSXYQmRkJI0bNy5yPD09nccff/zeByQiIiJSimkdbLkpT0/Pkg6hVLl8+TIVKlQo6TBERESkhGkG+z6Qk5NDaGgoZrMZLy8vZsyYQWBgICNGjABuXKrh5uZGTEyMsX/mzBl69+6Nm5sb7u7udO/endTUVON8fHw8LVu2xMnJCTc3N9q2bcvp06eJiYkhKiqKpKQkTCYTJpPJ6PeP4x48eJDOnTvj4OBApUqVGDx4MNnZ2cb5sLAwevTowfTp0/Hy8qJSpUoMGTKEvLy8Yj2Hjz/+mObNm+Ps7Iynpyf9+vUjIyPD4h5MJhMbN26kefPmODo68uijj5KcnGy0SUpKolOnTjg7O+Pi4kKzZs3Ys2cPhYWFeHh48PnnnxttGzdujJeXl7G/detW7OzsuHDhAgDnzp1j4MCBeHh44OLiQufOnUlKSjLaX5v5/+CDD6hRowb29vbFuk8REREp25Rg3wfGjBlDQkICK1euZN26dcTHx7Nv375iX5+Xl0dwcDDOzs5s2bKFbdu2YTab6datG5cvX+bKlSv06NGDjh07cuDAAXbs2MHgwYMxmUz06dOHV199lfr165Oenk56ejp9+vQpMkZOTg7BwcFUrFiRxMREPvvsMzZs2MDQoUMt2m3atImUlBQ2bdpEbGwsMTExFr8I3O4+Jk+eTFJSEitWrCA1NZWwsLAi7V577TVmzJjBnj17KF++PC+88IJxrn///jz88MMkJiayd+9exo8fj62tLSaTiQ4dOhAfHw/A77//ztGjR7l48SLHjh0DICEhgRYtWuDoePXbFZ955hkyMjL49ttv2bt3L02bNqVLly789ttvxngnT57kiy++4Msvv2T//v03vK/c3FyysrIsNhERESm7VCJSwrKzs/nwww/55JNP6NKlCwCxsbE8/PDDxe5j2bJlFBQU8MEHH2AymQBYtGgRbm5uxMfH07x5czIzM3nyySepVasWAAEBAcb1ZrOZ8uXL37IkJC4ujkuXLrF48WKcnJwAmDdvHiEhIbz11ltUqVIFgIoVKzJv3jxsbGyoW7cuTzzxBBs3bmTQoEG3vY/rE+WaNWsyZ84cWrRoQXZ2Nmaz2Tj35ptv0rFjRwDGjx/PE088waVLl7C3tyctLY0xY8ZQt25dAOrUqWNcFxgYyIIFCwDYvHkzTZo0wdPTk/j4eOrWrUt8fLzR79atW9m9ezcZGRnY2dkBMH36dFasWMHnn3/O4MGDgatlIYsXL8bDw+Om9zVt2jSioqJue/8iIiJSNmgGu4SlpKRw+fJlWrVqZRxzd3fH39+/2H0kJSVx8uRJnJ2dMZvNmM1m3N3duXTpEikpKbi7uxMWFkZwcDAhISHMnj2b9PT0O4rz6NGjNGrUyEiuAdq2bUtBQYFFiUb9+vWxsbEx9r28vCzKPG5l7969hISE4Ovri7Ozs5HspqWlWbRr2LChRf+AMcaoUaMYOHAgQUFBREdHk5KSYrTt2LEjR44c4X//+x8JCQkEBgYSGBhIfHw8eXl5bN++ncDAQODqM83OzqZSpUrGMzWbzZw6dcqiz2rVqt0yuQaIiIggMzPT2M6cOVOs5yEiIiKlkxLsUsBkMlFYWGhx7Pq65uzsbJo1a8b+/fsttuPHj9OvXz/g6oz2jh07ePTRR1m2bBl+fn7s3LnT6rHa2toWib2goOC2110rQXFxcWHJkiUkJiby1VdfAVdniW82xrUZ+2tjREZGcvjwYZ544gm+++476tWrZ/TToEED3N3dSUhIsEiwExISSExMJC8vj0cffRS4+ky9vLyKPNPk5GTGjBljjH/9Lxw3Y2dnh4uLi8UmIiIiZZdKREpYrVq1sLW1ZdeuXfj6+gJX64OPHz9uzOB6eHhYzDifOHHCeBEPoGnTpixbtoyHHnrolslbkyZNaNKkCREREbRp04a4uDhat25NhQoVyM/Pv2WcAQEBxMTEkJOTYySV27Zto1y5cnc0234zx44d4+zZs0RHR+Pj4wPAnj17/lRffn5++Pn5MXLkSPr27cuiRYvo2bMnJpOJ9u3bs3LlSg4fPky7du1wdHQkNzeXBQsW0Lx5c+PemjZtys8//0z58uWpXr36X74/EREReXBoBruEmc1mwsPDGTNmDN999x2HDh0iLCyMcuX+74+mc+fOzJs3j++//549e/bw0ksvWczi9u/fn8qVK9O9e3e2bNnCqVOniI+PZ9iwYfz444+cOnWKiIgIduzYwenTp1m3bh0nTpww6rCrV6/OqVOn2L9/P7/++iu5ublF4uzfvz/29vYMGDCAQ4cOsWnTJl555RWee+45o/76r/D19aVChQrMnTuXH374gVWrVjF58uQ76uPixYsMHTqU+Ph4Tp8+zbZt20hMTLSoNw8MDGTp0qU0btwYs9lMuXLl6NChA0uWLDF+oQEICgqiTZs29OjRg3Xr1pGamsr27dt57bXX/nTiLyIiIg8GJdj3gXfeeYf27dsTEhJCUFAQ7dq1o1mzZsb5GTNm4OPjQ/v27enXrx+jR482VroAcHR0ZPPmzfj6+tKrVy8CAgIIDw/n0qVLuLi44OjoyLFjx3jqqafw8/Nj8ODBDBkyhBdffBGAp556im7dutGpUyc8PDxYunRpkRgdHR1Zu3Ytv/32Gy1atODpp5+mS5cuzJs3zyrPwMPDg5iYGD777DPq1atHdHQ006dPv6M+bGxsOHv2LKGhofj5+dG7d28ef/xxixcMO3bsSH5+vlFrDVeT7j8eM5lMfPPNN3To0IHnn38ePz8/nn32WU6fPm2VXyhERESk7DIV/rG4V+4LgYGBNG7cmFmzZpV0KGJlWVlZuLq64jNiOeXsHG9/gYiIlEqp0U+UdAhiRdf+/s7MzLzt+1SawRYRERERsSIl2HJPbNmyxWK5uz9uIiIiImWFVhG5T137xsGyonnz5jf9pkMRERGRskQJttwTDg4O1K5du6TDEBEREbnrlGCLlJBDUcH60hkREZEySDXYIiIiIiJWpARbRERERMSKlGCLiIiIiFiREmwREREREStSgi0iIiIiYkVKsEVERERErEgJtoiIiIiIFSnBFhERERGxIiXYIiIiIiJWpARbRERERMSKlGCLiIiIiFiREmwREREREStSgi0iIiIiYkVKsEVERERErEgJtoiIiIiIFZUv6QBEHjSFhYUAZGVllXAkIiIiUlzX/t6+9vf4rSjBFrnHzp49C4CPj08JRyIiIiJ36vz587i6ut6yjRJskXvM3d0dgLS0tNv+Byp/TlZWFj4+Ppw5cwYXF5eSDqdM0jO++/SM7z4947uvLD3jwsJCzp8/j7e3923bKsEWucfKlbv66oOrq2up/5/N/c7FxUXP+C7TM7779IzvPj3ju6+sPOPiTozpJUcREREREStSgi0iIiIiYkVKsEXuMTs7OyZOnIidnV1Jh1Jm6RnffXrGd5+e8d2nZ3z3PajP2FRYnLVGRERERESkWDSDLSIiIiJiRUqwRURERESsSAm2iIiIiIgVKcEWEREREbEiJdgi99i//vUvqlevjr29Pa1atWL37t0lHVKZERkZiclkstjq1q1b0mGVaps3byYkJARvb29MJhMrVqywOF9YWMgbb7yBl5cXDg4OBAUFceLEiZIJtpS63TMOCwsr8rnu1q1byQRbCk2bNo0WLVrg7OzMQw89RI8ePUhOTrZoc+nSJYYMGUKlSpUwm8089dRT/PLLLyUUcelTnGccGBhY5HP80ksvlVDEd58SbJF7aNmyZYwaNYqJEyeyb98+GjVqRHBwMBkZGSUdWplRv3590tPTjW3r1q0lHVKplpOTQ6NGjfjXv/51w/Nvv/02c+bMYf78+ezatQsnJyeCg4O5dOnSPY609LrdMwbo1q2bxed66dKl9zDC0i0hIYEhQ4awc+dO1q9fT15eHo899hg5OTlGm5EjR/Kf//yHzz77jISEBH766Sd69epVglGXLsV5xgCDBg2y+By//fbbJRTxPVAoIvdMy5YtC4cMGWLs5+fnF3p7exdOmzatBKMqOyZOnFjYqFGjkg6jzAIKv/rqK2O/oKCg0NPTs/Cdd94xjp07d67Qzs6ucOnSpSUQYen3x2dcWFhYOGDAgMLu3buXSDxlUUZGRiFQmJCQUFhYePUza2trW/jZZ58ZbY4ePVoIFO7YsaOkwizV/viMCwsLCzt27Fg4fPjwkgvqHtMMtsg9cvnyZfbu3UtQUJBxrFy5cgQFBbFjx44SjKxsOXHiBN7e3tSsWZP+/fuTlpZW0iGVWadOneLnn3+2+Ey7urrSqlUrfaatLD4+noceegh/f3/+8Y9/cPbs2ZIOqdTKzMwEwN3dHYC9e/eSl5dn8TmuW7cuvr6++hz/SX98xtcsWbKEypUr88gjjxAREcGFCxdKIrx7onxJByDyoPj111/Jz8+nSpUqFserVKnCsWPHSiiqsqVVq1bExMTg7+9Peno6UVFRtG/fnkOHDuHs7FzS4ZU5P//8M8ANP9PXzslf161bN3r16kWNGjVISUnhn//8J48//jg7duzAxsampMMrVQoKChgxYgRt27blkUceAa5+jitUqICbm5tFW32O/5wbPWOAfv36Ua1aNby9vTlw4ADjxo0jOTmZL7/8sgSjvXuUYItImfH4448bPzds2JBWrVpRrVo1li9fTnh4eAlGJvLnPfvss8bPDRo0oGHDhtSqVYv4+Hi6dOlSgpGVPkOGDOHQoUN6N+MuutkzHjx4sPFzgwYN8PLyokuXLqSkpFCrVq17HeZdpxIRkXukcuXK2NjYFHkz/ZdffsHT07OEoirb3Nzc8PPz4+TJkyUdSpl07XOrz/S9VbNmTSpXrqzP9R0aOnQoX3/9NZs2beLhhx82jnt6enL58mXOnTtn0V6f4zt3s2d8I61atQIos59jJdgi90iFChVo1qwZGzduNI4VFBSwceNG2rRpU4KRlV3Z2dmkpKTg5eVV0qGUSTVq1MDT09PiM52VlcWuXbv0mb6LfvzxR86ePavPdTEVFhYydOhQvvrqK7777jtq1Khhcb5Zs2bY2tpafI6Tk5NJS0vT57iYbveMb2T//v0AZfZzrBIRkXto1KhRDBgwgObNm9OyZUtmzZpFTk4Ozz//fEmHViaMHj2akJAQqlWrxk8//cTEiROxsbGhb9++JR1aqZWdnW0xw3Tq1Cn279+Pu7s7vr6+jBgxgilTplCnTh1q1KjBhAkT8Pb2pkePHiUXdClzq2fs7u5OVFQUTz31FJ6enqSkpDB27Fhq165NcHBwCUZdegwZMoS4uDhWrlyJs7OzUVft6uqKg4MDrq6uhIeHM2rUKNzd3XFxceGVV16hTZs2tG7duoSjLx1u94xTUlKIi4vj//2//0elSpU4cOAAI0eOpEOHDjRs2LCEo79LSnoZE5EHzdy5cwt9fX0LK1SoUNiyZcvCnTt3lnRIZUafPn0Kvby8CitUqFBYtWrVwj59+hSePHmypMMq1TZt2lQIFNkGDBhQWFh4dam+CRMmFFapUqXQzs6usEuXLoXJycklG3Qpc6tnfOHChcLHHnus0MPDo9DW1rawWrVqhYMGDSr8+eefSzrsUuNGzxYoXLRokdHm4sWLhS+//HJhxYoVCx0dHQt79uxZmJ6eXnJBlzK3e8ZpaWmFHTp0KHR3dy+0s7MrrF27duGYMWMKMzMzSzbwu8hUWFhYeC8TehERERGRskw12CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsERERERErUoItIiIiImJFSrBFRERERKxICbaIiIiIiBUpwRYRERERsSIl2CIiIiIiVqQEW0RERETEipRgi4iIiIhYkRJsEREREREr+v/hGCV9V+/6XAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGdCAYAAACPVuWVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAB4nElEQVR4nO3deXhO1/7//+dNZJLJkEpUIqZEqCHEEIogmvSjjqEtJadoDR2oqaYcDQklqqipyqGVaMXQCS01VpSYYkhQBKmItunRaiViiJD8/vCzv+7GEL0R4fW4rn1d9l5rr/1eO3eb+5211t6mvLy8PERERERERCxQrLADEBERERGRok+JhYiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWMyqsAMQkcdHbm4uv/76K46OjphMpsIOR0RERAogLy+Pc+fOUb58eYoVu/W4hBILEXlgfv31Vzw8PAo7DBEREfkHTp06RYUKFW5ZrsRCRB4YR0dH4Nr/mJycnAo5GhERESmIzMxMPDw8jN/jt6LEQkQemOvTn5ycnJRYiIiIFDF3msasxdsiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxq8IOQEQeP0+NWUsxG/tblqdObPsAoxEREZF7QSMWIiIiIiJiMSUWIiIiIiJiMSUWIiIiIiJiMSUWIiIiIiJiMSUWIiIiIiJiMSUWIgUQHx9PrVq1KFGiBB06dCAuLg6TycTZs2dveU50dDQuLi5mx/773//i4eFBsWLFmDZt2n2NWURERORBUmIh8jeBgYEMGjTI7NiQIUOoW7cuJ06cIDo6miZNmpCeno6zs3OB283MzKR///6MGDGCX375hb59+97jyO9OamoqJpOJxMTEQo1DREREHg1KLEQKICUlhVatWlGhQgVcXFywtrbGzc0Nk8lU4DbS0tLIycmhbdu2uLu7Y29/6/c4FDU5OTmFHYKIiIgUMiUWIjfo2bMnmzdvZvr06ZhMJmM7c+YMr776KiaTiejo6JtOhYqOjsbT0xN7e3s6duzImTNnzMpq1aoFQOXKlTGZTKSmpt4yjqNHj2IymThy5IjZ8Q8++IAqVaoY+wcPHuTZZ5/FwcGBcuXK8fLLL/PHH38Y5bm5uUyaNImqVatiY2ODp6cn48ePB6BSpUoA+Pn5YTKZCAwMNM4ZO3YsFSpUwMbGhrp167JmzRqjzesjHUuXLqVFixbY2tqyaNGiu7vRIiIi8shRYiFyg+nTpxMQEECfPn1IT0/n559/5ueff8bJyYlp06aRnp5Oly5d8p23c+dOevXqRf/+/UlMTKRly5a8++67RnmXLl3YsGEDALt27SI9PR0PD49bxuHt7Y2/v3++L+yLFi2iW7duAJw9e5ZWrVrh5+fH7t27WbNmDf/73//o3LmzUT8sLIyJEycSHh7OoUOHiI2NpVy5ckYcABs2bCA9PZ2vvvrKuAdTpkxh8uTJ7N+/n+DgYP71r39x7Ngxs1hGjhzJwIEDOXz4MMHBwTftR3Z2NpmZmWabiIiIPJqsCjsAkYeJs7Mz1tbW2Nvb4+bmZhw3mUw4OzubHbvR9OnTCQkJYfjw4cC1xGDbtm3GX/rt7OwoU6YMAK6urrds50ahoaHMmjWLcePGAddGMfbs2cNnn30GwKxZs/Dz82PChAnGOZ988gkeHh4cPXoUd3d3pk+fzqxZs+jRowcAVapU4emnnzbiAChTpoxZPJMnT2bEiBG89NJLALz33nts2rSJadOm8eGHHxr1Bg0aRKdOnW7bh6ioKCIjI+/YVxERESn6NGIhcg8cPnyYRo0amR0LCAiwqM2XXnqJ1NRUduzYAVwbrahXrx7Vq1cHICkpiU2bNuHg4GBs18tSUlI4fPgw2dnZtG7dusDXzMzM5Ndff6Vp06Zmx5s2bcrhw4fNjvn7+9+xvbCwMDIyMozt1KlTBY5FREREihaNWIg8pNzc3GjVqhWxsbE0btyY2NhY3njjDaM8KyuLdu3a8d577+U7193dnZ9++um+xleyZMk71rGxscHGxua+xiEiIiIPB41YiPyNtbU1V69evatzfH192blzp9mx6yMNlggNDWXp0qVs376dn376yZieBFCvXj1+/PFHvLy8qFq1qtlWsmRJqlWrhp2dHRs3brxp29bW1gBmfXVycqJ8+fLEx8eb1Y2Pj6dGjRoW90dEREQeXUosRP7Gy8uLnTt3kpqayh9//EFubu4dzxkwYABr1qxh8uTJHDt2jFmzZpk9Semf6tSpE+fOneONN96gZcuWlC9f3ijr168ff/75J127diUhIYGUlBTWrl3LK6+8wtWrV7G1tWXEiBEMHz6chQsXkpKSwo4dO/j4448BeOKJJ7CzszMWfWdkZAAwbNgw3nvvPZYuXUpycjIjR44kMTGRgQMHWtwfEREReXQpsRD5m6FDh1K8eHFq1KiBq6sraWlpdzyncePGzJs3j+nTp1OnTh3WrVvHO++8Y3Esjo6OtGvXjqSkJEJDQ83Kro8sXL16lWeeeYZatWoxaNAgXFxcKFbs2n/a4eHhvP3224wePRpfX1+6dOnC6dOnAbCysmLGjBnMnTuX8uXL0759e+BakjRkyBDefvttatWqxZo1a1i5ciXVqlWzuD8iIiLy6DLl5eXlFXYQIvJ4yMzMxNnZGY9Byyhmc+sXBKZObPsAoxIREZHbuf77OyMjAycnp1vW04iFiIiIiIhYTImFSCGpWbOm2aNib9z0JmsREREpavS4WZFCsnr1anJycm5adv3t2CIiIiJFhdZYiMgDU9A5miIiIvLw0BoLERERERF5YJRYiIiIiIiIxZRYiIiIiIiIxZRYiIiIiIiIxZRYiIiIiIiIxfS4WRF54J4as/a2b96Wx4PesC4i8mjRiIWIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMiUURZzKZWL58eWGHIQUQGBjIoEGD7nm70dHRuLi43LZOREQEdevWNfZ79uxJhw4d7nksIiIi8vjSU6GKiIiICJYvX05iYqLZ8fT0dEqVKlU4QUmRNX36dPLy8go7DBEREXmEKLEo4tzc3Ao7hCLl8uXLWFtbF3YYhc7Z2bmwQxAREZFHjKZCFdD58+fp3r07Dg4OuLu7M2XKFLOpLTebkuTi4kJ0dLSxf+rUKTp37oyLiwulS5emffv2pKamGuVxcXE0bNiQkiVL4uLiQtOmTTl58iTR0dFERkaSlJSEyWTCZDIZ7f79ugcOHKBVq1bY2dlRpkwZ+vbtS1ZWllF+fQrM5MmTcXd3p0yZMvTr14+cnJwC3YdPP/0Uf39/HB0dcXNzo1u3bpw+fdqsDyaTiY0bN+Lv74+9vT1NmjQhOTnZqJOUlETLli1xdHTEycmJ+vXrs3v3bvLy8nB1deWLL74w6tatWxd3d3djf+vWrdjY2HDhwgUAzp49S+/evXF1dcXJyYlWrVqRlJRk1L8+BWj+/PlUqlQJW1vbO/YxNzeXqKgoKlWqhJ2dHXXq1DGL6Xof165di5+fH3Z2drRq1YrTp0/z3Xff4evri5OTE926dTPivO7KlSv0798fZ2dnypYtS3h4uNnIQXZ2NkOHDuXJJ5+kZMmSNGrUiLi4OLM2oqOj8fT0xN7eno4dO3LmzJl8fZg4cSLlypXD0dGRXr16cenSJbPyv0+FCgwMZMCAAQwfPpzSpUvj5uZGRESE2TlHjhzh6aefxtbWlho1arBhwwZNxRMRERGDEosCGjZsGJs3b2bFihWsW7eOuLg49u7dW+Dzc3JyCA4OxtHRkS1bthAfH4+DgwMhISFcvnyZK1eu0KFDB1q0aMH+/fvZvn07ffv2xWQy0aVLF95++21q1qxJeno66enpdOnSJd81zp8/T3BwMKVKlSIhIYHPP/+cDRs20L9/f7N6mzZtIiUlhU2bNhETE0N0dLRZAnSnfowbN46kpCSWL19OamoqPXv2zFdv1KhRTJkyhd27d2NlZcWrr75qlIWGhlKhQgUSEhLYs2cPI0eOpESJEphMJpo3b258kf7rr784fPgwFy9e5MiRIwBs3ryZBg0aYG9/7eVqL774ovGFfs+ePdSrV4/WrVvz559/Gtc7fvw4X375JV999VW+qWQ3ExUVxcKFC5kzZw4//vgjgwcP5t///jebN282qxcREcGsWbPYtm2bkTROmzaN2NhYVq1axbp165g5c6bZOTExMVhZWbFr1y6mT5/O1KlTmT9/vlHev39/tm/fzpIlS9i/fz8vvvgiISEhHDt2DICdO3fSq1cv+vfvT2JiIi1btuTdd981u8ayZcuIiIhgwoQJ7N69G3d3d2bPnn3HfsfExFCyZEl27tzJpEmTGDt2LOvXrwfg6tWrdOjQAXt7e3bu3Ml///tfRo0adcc2s7OzyczMNNtERETk0aSpUAWQlZXFxx9/zGeffUbr1q2Ba1/CKlSoUOA2li5dSm5uLvPnz8dkMgGwYMECXFxciIuLw9/fn4yMDJ577jmqVKkCgK+vr3G+g4MDVlZWt536FBsby6VLl1i4cCElS5YEYNasWbRr14733nuPcuXKAVCqVClmzZpF8eLFqV69Om3btmXjxo306dPnjv24MUGoXLkyM2bMoEGDBmRlZeHg4GCUjR8/nhYtWgAwcuRI2rZty6VLl7C1tSUtLY1hw4ZRvXp1AKpVq2acFxgYyNy5cwH44Ycf8PPzw83Njbi4OKpXr05cXJzR7tatW9m1axenT5/GxsYGgMmTJ7N8+XK++OIL+vbtC1yb/rRw4UJcXV3v2L/s7GwmTJjAhg0bCAgIMPq5detW5s6da1wb4N1336Vp06YA9OrVi7CwMFJSUqhcuTIAL7zwAps2bWLEiBHGOR4eHnzwwQeYTCZ8fHw4cOAAH3zwAX369CEtLY0FCxaQlpZG+fLlARg6dChr1qxhwYIFTJgwgenTpxMSEsLw4cMB8Pb2Ztu2baxZs8a4xrRp0+jVqxe9evUy4tywYUO+UYu/q127NmPGjDF+JrNmzWLjxo20adOG9evXk5KSQlxcnPEZHD9+PG3atLltm1FRUURGRt7hrouIiMijQCMWBZCSksLly5dp1KiRcax06dL4+PgUuI2kpCSOHz+Oo6MjDg4OODg4ULp0aS5dukRKSgqlS5emZ8+eBAcH065dO6ZPn056evpdxXn48GHq1KljJBUATZs2JTc312wqUs2aNSlevLix7+7ubjad6Xb27NlDu3bt8PT0xNHR0fiinZaWZlavdu3aZu0DxjWGDBlC7969CQoKYuLEiaSkpBh1W7RowaFDh/j999/ZvHkzgYGBBAYGEhcXR05ODtu2bSMwMBC4dk+zsrIoU6aMcU8dHBw4ceKEWZsVK1YsUFIB10Y3Lly4QJs2bczaXLhwoVmbf+9juXLlsLe3N5KK68f+fl8bN25sJJYAAQEBHDt2jKtXr3LgwAGuXr2Kt7e32bU3b95sXPvw4cNmn8PrbdyoIHVu5sb+gPnnIjk5GQ8PD7PEtmHDhndsMywsjIyMDGM7derUHc8RERGRokkjFveIyWTK95SdG9ctZGVlUb9+fRYtWpTv3OtfehcsWMCAAQNYs2YNS5cu5Z133mH9+vU0btz4nsZaokSJfLHn5ube8bzrU62Cg4NZtGgRrq6upKWlERwczOXLl295jetfpK9fIyIigm7durFq1Sq+++47xowZw5IlS+jYsSO1atWidOnSbN68mc2bNzN+/Hjc3Nx47733SEhIICcnhyZNmgDX7qm7u3u+NQiA2eNXb0y07uT6epRVq1bx5JNPmpVdHxW5VR//6X298drFixdnz549ZokfYDYadL9YGv/N2NjY5LtvIiIi8mhSYlEAVapUoUSJEuzcuRNPT0/g2vz/o0ePGn+xd3V1NRthOHbsmNnC3Xr16rF06VKeeOIJnJycbnktPz8//Pz8CAsLIyAggNjYWBo3boy1tTVXr169bZy+vr5ER0dz/vx548t0fHw8xYoVu6vRlVs5cuQIZ86cYeLEiXh4eACwe/fuf9SWt7c33t7eDB48mK5du7JgwQI6duyIyWSiWbNmrFixgh9//JGnn34ae3t7srOzmTt3Lv7+/kbf6tWrx2+//YaVlRVeXl4W9w+gRo0a2NjYkJaWZjbt6V7ZuXOn2f6OHTuoVq0axYsXx8/Pj6tXr3L69GmaNWt20/N9fX1v2sbN6nTv3v2Wde6Wj48Pp06d4n//+58xpS4hIcGiNkVEROTRoqlQBeDg4ECvXr0YNmwY33//PQcPHqRnz54UK/b/bl+rVq2YNWsW+/btY/fu3bz++utmfwEODQ2lbNmytG/fni1btnDixAni4uIYMGAAP//8MydOnCAsLIzt27dz8uRJ1q1bx7Fjx4x1Fl5eXpw4cYLExET++OMPsrOz88UZGhqKra0tPXr04ODBg2zatIm33nqLl19+2fgyaAlPT0+sra2ZOXMmP/30EytXrmTcuHF31cbFixfp378/cXFxnDx5kvj4eBISEszWkwQGBrJ48WLq1q2Lg4MDxYoVo3nz5ixatMjsy35QUBABAQF06NCBdevWkZqayrZt2xg1atQ/TngcHR0ZOnQogwcPJiYmhpSUFPbu3cvMmTOJiYn5R23eKC0tjSFDhpCcnMzixYuZOXMmAwcOBK4lW6GhoXTv3p2vvvqKEydOsGvXLqKioli1ahWAMaI1efJkjh07xqxZs8zWVwAMHDiQTz75hAULFnD06FHGjBnDjz/+aFHcbdq0oUqVKvTo0YP9+/cTHx/PO++8A2A2tUtEREQeX0osCuj999+nWbNmtGvXjqCgIJ5++mnq169vlE+ZMgUPDw+aNWtGt27dGDp0qPHkIgB7e3t++OEHPD096dSpE76+vsZjQJ2cnLC3t+fIkSM8//zzeHt707dvX/r168drr70GwPPPP09ISAgtW7bE1dWVxYsX54vR3t6etWvX8ueff9KgQQNeeOEFWrduzaxZs+7JPXB1dSU6OprPP/+cGjVqMHHiRCZPnnxXbRQvXpwzZ87QvXt3vL296dy5M88++6zZAt8WLVpw9epVYy0FXEs2/n7MZDKxevVqmjdvziuvvIK3tzcvvfQSJ0+etCiRGjduHOHh4URFReHr60tISAirVq2iUqVK/7jN67p3787Fixdp2LAh/fr1Y+DAgcYic7g2Ha579+68/fbb+Pj40KFDBxISEoyRssaNGzNv3jymT59OnTp1WLdunfEF/7ouXboQHh7O8OHDqV+/PidPnuSNN96wKO7ixYuzfPlysrKyaNCgAb179zaeClWQR/iKiIjIo8+Up9fv/mOBgYHUrVuXadOmFXYoIg9cfHw8Tz/9NMePHzeeZHYnmZmZODs74zFoGcVs7O98gjzSUie2LewQRESkAK7//s7IyLjtlH6tsRCRAvn6669xcHCgWrVqHD9+nIEDB9K0adMCJxUiIiLyaFNiIYYtW7bw7LPP3rL8xjd4F1VpaWnUqFHjluWHDh0yph2JuXPnzjFixAjS0tIoW7YsQUFBTJkypbDDEhERkYeEpkKJ4eLFi/zyyy+3LK9ateoDjOb+uHLlCqmpqbcs9/LywspK+fb9oqlQciNNhRIRKRo0FUrump2d3SORPNyOlZXVI99HERERkcKgxEJEHriDkcG3/YuHiIiIFD163KyIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMi7dF5IF7asxaPW72PtJjXEVEpDBoxEJERERERCymxEJERERERCymxEJERERERCymxEJERERERCxW6IlFamoqJpOJxMTEQrl+z5496dChQ6Fc+24VpVjFXFxcHCaTibNnz97ztr28vJg2bdpt65hMJpYvXw4U/n9zIiIi8mgqkk+F6tmzJ2fPnjW+KIlIwXl4eJCenk7ZsmULOxQRERF5hBT6iMWj7vLly4UdgoiZ4sWL4+bmhpVVkfy7goiIiDyk7iqxuNmUi7p16xIREQFcm27x0Ucf8eyzz2JnZ0flypX54osvzOrv2rULPz8/bG1t8ff3Z9++fWblV69epVevXlSqVAk7Ozt8fHyYPn26UR4REUFMTAwrVqzAZDJhMpmIi4sD4NSpU3Tu3BkXFxdKly5N+/btSU1NNWt7yJAhuLi4UKZMGYYPH05eXl6B+3/u3DlCQ0MpWbIk7u7ufPDBBwQGBjJo0CCzezRu3Di6d++Ok5MTffv2BWDEiBF4e3tjb29P5cqVCQ8PJycnx6xfdevWZe7cuXh4eGBvb0/nzp3JyMjIF8fkyZNxd3enTJky9OvXz6yd25k9ezbVqlXD1taWcuXK8cILLxhlubm5REVFGfe9Tp06+X52q1evxtvbGzs7O1q2bEl0dLTZ9J7rfbjRtGnT8PLyMjs2f/58fH19sbW1pXr16syePdsouz5N56uvvqJly5bY29tTp04dtm/fbtZGfHw8gYGB2NvbU6pUKYKDg/nrr78K3JfbOXjwIM8++ywODg6UK1eOl19+mT/++MMoDwwM5K233mLQoEGUKlWKcuXKMW/ePM6fP88rr7yCo6MjVatW5bvvvsvXdnx8PLVr18bW1pbGjRtz8OBBs/KtW7fSrFkz7Ozs8PDwYMCAAZw/f94oP336NO3atcPOzo5KlSqxaNGifNc4duwYzZs3x9bWlho1arB+/Xqz8r9Phbo+TWvjxo34+/tjb29PkyZNSE5ONjvv3Xff5YknnsDR0ZHevXszcuTIfD9vEREReXzd8xGL8PBwnn/+eZKSkggNDeWll17i8OHDAGRlZfHcc89Ro0YN9uzZQ0REBEOHDjU7Pzc3lwoVKvD5559z6NAhRo8ezX/+8x+WLVsGwNChQ+ncuTMhISGkp6eTnp5OkyZNyMnJITg4GEdHR7Zs2UJ8fDwODg6EhIQYowZTpkwhOjqaTz75hK1bt/Lnn3/y9ddfF7hvQ4YMIT4+npUrV7J+/Xq2bNnC3r1789WbPHkyderUYd++fYSHhwPg6OhIdHQ0hw4dYvr06cybN48PPvjA7Lzjx4+zbNkyvvnmG9asWcO+fft48803zeps2rSJlJQUNm3aRExMDNHR0URHR98x9t27dzNgwADGjh1LcnIya9asoXnz5kZ5VFQUCxcuZM6cOfz4448MHjyYf//732zevBm4lrR16tSJdu3akZiYaHyxvFuLFi1i9OjRjB8/nsOHDzNhwgTCw8OJiYkxqzdq1CiGDh1KYmIi3t7edO3alStXrgCQmJhI69atqVGjBtu3b2fr1q20a9eOq1evFqgvt3P27FlatWqFn58fu3fvZs2aNfzvf/+jc+fOZvViYmIoW7Ysu3bt4q233uKNN97gxRdfpEmTJuzdu5dnnnmGl19+mQsXLpidN2zYMKZMmUJCQgKurq60a9fOSAxTUlIICQnh+eefZ//+/SxdupStW7fSv39/4/yePXty6tQpNm3axBdffMHs2bM5ffq0UZ6bm0unTp2wtrZm586dzJkzhxEjRhToZzNq1CimTJnC7t27sbKy4tVXXzXKFi1axPjx43nvvffYs2cPnp6efPTRR3dsMzs7m8zMTLNNREREHk33fC7Eiy++SO/evQEYN24c69evZ+bMmcyePZvY2Fhyc3P5+OOPsbW1pWbNmvz888+88cYbxvklSpQgMjLS2K9UqRLbt29n2bJldO7cGQcHB+zs7MjOzsbNzc2o99lnn5Gbm8v8+fMxmUwALFiwABcXF+Li4njmmWeYNm0aYWFhdOrUCYA5c+awdu3aAvXr3LlzxMTEEBsbS+vWrY32y5cvn69uq1atePvtt82OvfPOO8a/vby8GDp0KEuWLGH48OHG8UuXLrFw4UKefPJJAGbOnEnbtm2ZMmWK0ddSpUoxa9YsihcvTvXq1Wnbti0bN26kT58+t40/LS2NkiVL8txzz+Ho6EjFihXx8/MDrn35mzBhAhs2bCAgIACAypUrs3XrVubOnUuLFi346KOPqFKlClOmTAHAx8eHAwcO8N577xXo/l03ZswYpkyZYvwMKlWqxKFDh5g7dy49evQw6g0dOpS2ba+9PTgyMpKaNWty/PhxqlevzqRJk/D39zcb6ahZs2aB+3I7s2bNws/PjwkTJhjHPvnkEzw8PDh69Cje3t4A1KlTx/iZhoWFMXHiRMqWLWv8HEaPHs1HH33E/v37ady4sVn/27RpA1xLTipUqMDXX39N586diYqKIjQ01BgBq1atGjNmzDDuf1paGt999x27du2iQYMGAHz88cf4+voa7W/YsIEjR46wdu1a47M5YcIEnn322Tv+bMaPH2/cn5EjR9K2bVsuXbqEra0tM2fOpFevXrzyyitG/9atW0dWVtZt24yKijL771lEREQeXfc8sbj+Ze7G/etTLg4fPmxMA7lVfYAPP/yQTz75hLS0NC5evMjly5fvOOUiKSmJ48eP4+joaHb80qVLpKSkkJGRQXp6Oo0aNTLKrKys8Pf3L9B0qJ9++omcnBwaNmxoHHN2dsbHxydfXX9//3zHli5dyowZM0hJSSErK4srV67g5ORkVsfT09NIKuDavcnNzSU5OdlILGrWrEnx4sWNOu7u7hw4cOCO8bdp04aKFStSuXJlQkJCCAkJoWPHjtjb23P8+HEuXLhgfOG97vLly0bycfjwYbN7dz2+u3H+/HlSUlLo1auXWSJ05coVnJ2dzerWrl3brI9wbRpQ9erVSUxM5MUXX7zpNQrSl9tJSkpi06ZNODg45CtLSUkxEosb4ytevDhlypShVq1axrFy5coZMd/oxntWunRpfHx8jBG9pKQk9u/fbza9KS8vj9zcXE6cOMHRo0exsrKifv36Rnn16tVxcXEx9g8fPoyHh4dZwlvQn9Ot7rmnpyfJycn5Rs8aNmzI999/f9s2w8LCGDJkiLGfmZmJh4dHgeIRERGRouWuEotixYrl+xJe0Pn9BbVkyRKGDh3KlClTCAgIwNHRkffff5+dO3fe9rysrCzq169/0znnrq6u9zTGOylZsqTZ/vbt2wkNDSUyMpLg4GCcnZ1ZsmSJ8df/u1GiRAmzfZPJRG5u7h3Pc3R0ZO/evcTFxbFu3TpGjx5NREQECQkJxl+dV61aZZbYANjY2BQ4tjt9Pq5fZ968efmSlBuTJTDv5/URqOv9tLOzu2UMlvYlKyuLdu3a3XQk5vqX7b/Hdz3G28VcEFlZWbz22msMGDAgX5mnpydHjx4tcFv/hKXx34yNjc1dfYZERESk6LqrxMLV1ZX09HRjPzMzkxMnTpjV2bFjB927dzfbv/6XYl9fXz799FNjesX18hvFx8fTpEkTs7+OpqSkmNWxtrY25tNfV69ePZYuXcoTTzyRbyTgOnd3d3bu3GmsLbhy5Qp79uyhXr16d+x75cqVKVGiBAkJCXh6egKQkZHB0aNHzdYq3My2bduoWLEio0aNMo6dPHkyX720tDR+/fVX46/NO3bsoFixYjcdFfknrKysCAoKIigoiDFjxuDi4sL3339PmzZtsLGxIS0t7ZZThXx9fVm5cqXZsb//7FxdXfntt9/Iy8szvpje+K6EcuXKUb58eX766SdCQ0P/cT9q167Nxo0bbzrFpkaNGnfsy+3Uq1ePL7/8Ei8vr/vy1KQdO3YYn5+//vqLo0ePGlOZ6tWrx6FDh6hatepNz61evbrxmb0+FSo5Odns3Ri+vr6cOnWK9PR0IxH6+8/pn/Dx8SEhIcHsv+2EhASL2xUREZFHx10t3m7VqhWffvopW7Zs4cCBA/To0SPfX5o///xzPvnkE44ePcqYMWPYtWuXsfi0W7dumEwm+vTpw6FDh1i9ejWTJ082O79atWrs3r2btWvXcvToUcLDw/N9gfHy8mL//v0kJyfzxx9/kJOTQ2hoKGXLlqV9+/Zs2bKFEydOEBcXx4ABA/j5558BGDhwIBMnTmT58uUcOXKEN998s8AvLHN0dKRHjx4MGzaMTZs28eOPP9KrVy+KFStmfIm+lWrVqpGWlsaSJUtISUlhxowZN100bmtrS48ePUhKSmLLli0MGDCAzp07m60l+ae+/fZbZsyYQWJiIidPnmThwoXk5ubi4+ODo6MjQ4cOZfDgwcTExJCSksLevXuZOXOmsaj69ddf59ixYwwbNozk5GRiY2PzLRoPDAzk999/Z9KkSaSkpPDhhx/mezJSZGQkUVFRzJgxg6NHj3LgwAEWLFjA1KlTC9yXsLAwEhISePPNN9m/fz9Hjhzho48+4o8//ihQX26nX79+/Pnnn3Tt2pWEhARSUlJYu3Ytr7zySr5k9p8YO3YsGzdu5ODBg/Ts2ZOyZcsaLz0cMWIE27Zto3///iQmJnLs2DFWrFhh/Pfj4+NDSEgIr732Gjt37mTPnj307t3bbAQnKCgIb29vs8/RjQntP/XWW2/x8ccfExMTw7Fjx3j33XfZv3//HT/7IiIi8vi4q8QiLCyMFi1a8Nxzz9G2bVs6dOhAlSpVzOpERkayZMkSateuzcKFC1m8eDE1atQAwMHBgW+++YYDBw7g5+fHqFGj8k05ee211+jUqRNdunShUaNGnDlzJt/c7j59+uDj44O/vz+urq7Ex8djb2/PDz/8gKenJ506dcLX15devXpx6dIlYwTj7bff5uWXX6ZHjx7GNKuOHTsWuP9Tp04lICCA5557jqCgIJo2bWo8NvV2/vWvfzF48GD69+9P3bp12bZtm/G0qBtVrVqVTp068X//938888wz1K5d22yBsiVcXFz46quvaNWqFb6+vsyZM4fFixcbi57HjRtHeHg4UVFR+Pr6EhISwqpVq6hUqRJwbSrOl19+yfLly6lTpw5z5swxW+AM1/5aPnv2bD788EPq1KnDrl278j31q3fv3syfP58FCxZQq1YtWrRoQXR0tHGdgvD29mbdunUkJSXRsGFDAgICWLFihTHCcKe+3E758uWJj4/n6tWrPPPMM9SqVYtBgwbh4uJCsWKWP0Rt4sSJDBw4kPr16/Pbb7/xzTffYG1tDVwbidm8eTNHjx6lWbNm+Pn5MXr0aLP1EtcfGNCiRQs6depE3759eeKJJ4zyYsWK8fXXX3Px4kUaNmxI7969GT9+vMVxh4aGEhYWxtChQ6lXrx4nTpygZ8+ed/zsi4iIyOPDlHc3L3K4U2MmE19//bXxF9hH3fnz53nyySeZMmUKvXr1sqitiIgIli9fbjZ16GEXFxdHy5Yt+euvv8wWEMvjoU2bNri5ufHpp58W+JzMzEycnZ3xGLSMYjb29zG6x1vqxLaFHYKIiDxCrv/+zsjIuOWSA7gPT4V6lO3bt48jR47QsGFDMjIyGDt2LADt27cv5MhE7q8LFy4wZ84cgoODKV68OIsXL2bDhg35Xr4nIiIij697/oK8oiotLQ0HB4dbbmlpacD/e/ldUFAQ58+fZ8uWLZQtW7aQo4ctW7bcNn655vXXX7/lPXr99dcLO7yHlslkYvXq1TRv3pz69evzzTff8OWXXxIUFFTYoYmIiMhD4p5OhSrKrly5Qmpq6i3L79dTgu6Vixcv8ssvv9yy/FZPGnrcnD59+pZvf3ZycjJbryD3nqZCPRiaCiUiIveSpkLdJSsrqyL95dvOzq5Ix/+gPPHEE0oeRERERO4DJRYi8sAdjAy+7V88REREpOjRGgsREREREbGYEgsREREREbGYEgsREREREbGYEgsREREREbGYFm+LyAP31Ji1etysiIjIPfQwPGpcIxYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRYiIiIiImIxJRaPqNTUVEwmE4mJiYVy/Z49e9KhQ4dCufbdKkqxioiIiDyslFiIQV+wRUREROSfUmIhRdLly5cLOwQRERERuYESi4eAl5cX06ZNMztWt25dIiIiADCZTHz00Uc8++yz2NnZUblyZb744guz+rt27cLPzw9bW1v8/f3Zt2+fWfnVq1fp1asXlSpVws7ODh8fH6ZPn26UR0REEBMTw4oVKzCZTJhMJuLi4gA4deoUnTt3xsXFhdKlS9O+fXtSU1PN2h4yZAguLi6UKVOG4cOHk5eXV+D+nzt3jtDQUEqWLIm7uzsffPABgYGBDBo0yOwejRs3ju7du+Pk5ETfvn0BGDFiBN7e3tjb21O5cmXCw8PJyckx61fdunWZO3cuHh4e2Nvb07lzZzIyMvLFMXnyZNzd3SlTpgz9+vUza+d2Zs+eTbVq1bC1taVcuXK88MILRllubi5RUVHGfa9Tp06+n93q1avx9vbGzs6Oli1bEh0djclk4uzZs2Z9uNG0adPw8vIyOzZ//nx8fX2xtbWlevXqzJ492yi7PjXuq6++omXLltjb21OnTh22b99u1kZ8fDyBgYHY29tTqlQpgoOD+euvvwrcFxEREXl8KbEoIsLDw3n++edJSkoiNDSUl156icOHDwOQlZXFc889R40aNdizZw8REREMHTrU7Pzc3FwqVKjA559/zqFDhxg9ejT/+c9/WLZsGQBDhw6lc+fOhISEkJ6eTnp6Ok2aNCEnJ4fg4GAcHR3ZsmUL8fHxODg4EBISYowaTJkyhejoaD755BO2bt3Kn3/+yddff13gvg0ZMoT4+HhWrlzJ+vXr2bJlC3v37s1Xb/LkydSpU4d9+/YRHh4OgKOjI9HR0Rw6dIjp06czb948PvjgA7Pzjh8/zrJly/jmm29Ys2YN+/bt48033zSrs2nTJlJSUti0aRMxMTFER0cTHR19x9h3797NgAEDGDt2LMnJyaxZs4bmzZsb5VFRUSxcuJA5c+bw448/MnjwYP7973+zefNm4FrS1qlTJ9q1a0diYiK9e/dm5MiRBb531y1atIjRo0czfvx4Dh8+zIQJEwgPDycmJsas3qhRoxg6dCiJiYl4e3vTtWtXrly5AkBiYiKtW7emRo0abN++na1bt9KuXTuuXr1aoL7cTHZ2NpmZmWabiIiIPJqsCjsAKZgXX3yR3r17AzBu3DjWr1/PzJkzmT17NrGxseTm5vLxxx9ja2tLzZo1+fnnn3njjTeM80uUKEFkZKSxX6lSJbZv386yZcvo3LkzDg4O2NnZkZ2djZubm1Hvs88+Izc3l/nz52MymQBYsGABLi4uxMXF8cwzzzBt2jTCwsLo1KkTAHPmzGHt2rUF6te5c+eIiYkhNjaW1q1bG+2XL18+X91WrVrx9ttvmx175513jH97eXkxdOhQlixZwvDhw43jly5dYuHChTz55JMAzJw5k7Zt2zJlyhSjr6VKlWLWrFkUL16c6tWr07ZtWzZu3EifPn1uG39aWholS5bkueeew9HRkYoVK+Ln5wdc+1I9YcIENmzYQEBAAACVK1dm69atzJ07lxYtWvDRRx9RpUoVpkyZAoCPjw8HDhzgvffeK9D9u27MmDFMmTLF+BlUqlSJQ4cOMXfuXHr06GHUGzp0KG3btgUgMjKSmjVrcvz4capXr86kSZPw9/c3G+moWbNmgftyM1FRUWafOxEREXl0KbEoIq5/mbtx//oTnw4fPkzt2rWxtbW9ZX2ADz/8kE8++YS0tDQuXrzI5cuX802x+bukpCSOHz+Oo6Oj2fFLly6RkpJCRkYG6enpNGrUyCizsrLC39+/QNOhfvrpJ3JycmjYsKFxzNnZGR8fn3x1/f398x1bunQpM2bMICUlhaysLK5cuYKTk5NZHU9PTyOpgGv3Jjc3l+TkZCOxqFmzJsWLFzfquLu7c+DAgTvG36ZNGypWrEjlypUJCQkhJCSEjh07Ym9vz/Hjx7lw4QJt2rQxO+fy5ctG8nH48GGze3c9vrtx/vx5UlJS6NWrl1kidOXKFZydnc3q1q5d26yPAKdPn6Z69eokJiby4osv3vQaBenLzYSFhTFkyBBjPzMzEw8Pj4J3TkRERIoMJRYPgWLFiuX7El7Q+f0FtWTJEoYOHcqUKVMICAjA0dGR999/n507d972vKysLOrXr8+iRYvylbm6ut7TGO+kZMmSZvvbt28nNDSUyMhIgoODcXZ2ZsmSJcZf/+9GiRIlzPZNJhO5ubl3PM/R0ZG9e/cSFxfHunXrGD16NBERESQkJJCVlQXAqlWrzBIbABsbmwLHdqfPx/XrzJs3L1+ScmOyBOb9vD4Cdb2fdnZ2t4zhn/bFxsbmrvoqIiIiRZcSi4eAq6sr6enpxn5mZiYnTpwwq7Njxw66d+9utn/9L8W+vr58+umnXLp0yRi12LFjh9n58fHxNGnSxGxtQUpKilkda2trYz79dfXq1WPp0qU88cQT+UYCrnN3d2fnzp3G2oIrV66wZ88e6tWrd8e+V65cmRIlSpCQkICnpycAGRkZHD161Gytws1s27aNihUrMmrUKOPYyZMn89VLS0vj119/NaZX7dixg2LFit10VOSfsLKyIigoiKCgIMaMGYOLiwvff/89bdq0wcbGhrS0tFtOFfL19WXlypVmx/7+s3N1deW3334jLy/PSAZufD9JuXLlKF++PD/99BOhoaH/uB+1a9dm48aNN526VKNGjTv2RURERB5vSiweAq1atSI6Opp27drh4uLC6NGj8/2l+fPPP8ff35+nn36aRYsWsWvXLj7++GMAunXrxqhRo+jTpw9hYWGkpqYyefJks/OrVavGwoULWbt2LZUqVeLTTz8lISGBSpUqGXW8vLxYu3YtycnJlClTBmdnZ0JDQ3n//fdp3749Y8eOpUKFCpw8eZKvvvqK4cOHU6FCBQYOHMjEiROpVq0a1atXZ+rUqcYTje7E0dGRHj16MGzYMEqXLs0TTzzBmDFjKFasmPEl+laqVatGWloaS5YsoUGDBqxateqmi8ZtbW3p0aMHkydPJjMzkwEDBtC5c2eztST/1LfffstPP/1E8+bNKVWqFKtXryY3NxcfHx8cHR0ZOnQogwcPJjc3l6effpqMjAzi4+NxcnKiR48evP7660yZMoVhw4bRu3dv9uzZk2/ReGBgIL///juTJk3ihRdeYM2aNXz33XdmiV5kZCQDBgzA2dmZkJAQsrOz2b17N3/99ZfZVKTbCQsLo1atWrz55pu8/vrrWFtbs2nTJl588UXKli17x76IiIjI401PhXoIhIWF0aJFC5577jnatm1Lhw4dqFKlilmdyMhIlixZQu3atVm4cCGLFy+mRo0aADg4OPDNN99w4MAB/Pz8GDVqVL7Fv6+99hqdOnWiS5cuNGrUiDNnzuR7MlKfPn3w8fHB398fV1dX4uPjsbe354cffsDT05NOnTrh6+tLr169uHTpkvHF9u233+bll1+mR48exjSrjh07Frj/U6dOJSAggOeee46goCCaNm1qPDb1dv71r38xePBg+vfvT926ddm2bZvxtKgbVa1alU6dOvF///d/PPPMM9SuXdtsgbIlXFxc+Oqrr2jVqhW+vr7MmTOHxYsXG4uex40bR3h4OFFRUfj6+hISEsKqVauMhM7T05Mvv/yS5cuXU6dOHebMmcOECRPMruHr68vs2bP58MMPqVOnDrt27cr31K/evXszf/58FixYQK1atWjRogXR0dFmieOdeHt7s27dOpKSkmjYsCEBAQGsWLECKyurAvVFREREHm+mvLt54YAUCpPJxNdff/3YvBX7/PnzPPnkk0yZMoVevXpZ1FZERATLly83mzr0sIuLi6Nly5b89ddfuLi4FHY491RmZibOzs54DFpGMRv7wg5HRETkkZE6se19a/v67++MjIxbTo0HTYWSh8C+ffs4cuQIDRs2JCMjg7FjxwLQvn37Qo5MRERERApKiYXcV2lpacaUrZs5dOgQcO3ld8nJyVhbW1O/fn22bNlC2bJlH1SYt7RlyxaeffbZW5Zff1qSiIiIyONOU6Hkvrpy5Qqpqam3LPfy8jLm8D+MLl68yC+//HLL8qpVqz7AaIo+TYUSERG5Px6GqVBKLETkgSno/5hERETk4VHQ3996KpSIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFjs4X0cj4g8sp4as1ZPhfr/3c+neIiIiDxIGrEQERERERGLKbEQERERERGLKbEQERERERGLKbEQERERERGLKbEQERERERGLKbEQeYh5eXkxbdq0wg4DgOjoaFxcXAo7DBEREXlIKbEQkXwepoRGREREigYlFiIiIiIiYjElFlIkrFmzhqeffhoXFxfKlCnDc889R0pKCgBNmjRhxIgRZvV///13SpQowQ8//ABAeno6bdu2xc7OjkqVKhEbG1vgv8rn5eURERGBp6cnNjY2lC9fngEDBhjls2fPplq1atja2lKuXDleeOEFoywwMJD+/fvTv39/nJ2dKVu2LOHh4eTl5f2j+3D27Fl69+6Nq6srTk5OtGrViqSkJKM8IiKCunXr8umnn+Ll5YWzszMvvfQS586dM+qcO3eO0NBQSpYsibu7Ox988AGBgYEMGjTIiPnkyZMMHjwYk8mEyWQyi2Ht2rX4+vri4OBASEgI6enp/6gvIiIi8mhRYiFFwvnz5xkyZAi7d+9m48aNFCtWjI4dO5Kbm0toaChLliwx+7K+dOlSypcvT7NmzQDo3r07v/76K3FxcXz55Zf897//5fTp0wW69pdffskHH3zA3LlzOXbsGMuXL6dWrVoA7N69mwEDBjB27FiSk5NZs2YNzZs3Nzs/JiYGKysrdu3axfTp05k6dSrz58//R/fhxRdf5PTp03z33Xfs2bOHevXq0bp1a/7880+jTkpKCsuXL+fbb7/l22+/ZfPmzUycONEoHzJkCPHx8axcuZL169ezZcsW9u7da5R/9dVXVKhQgbFjx5Kenm6WOFy4cIHJkyfz6aef8sMPP5CWlsbQoUNvGW92djaZmZlmm4iIiDyarAo7AJGCeP755832P/nkE1xdXTl06BCdO3dm0KBBbN261UgkYmNj6dq1KyaTiSNHjrBhwwYSEhLw9/cHYP78+VSrVq1A105LS8PNzY2goCBKlCiBp6cnDRs2NMpKlizJc889h6OjIxUrVsTPz8/sfA8PDz744ANMJhM+Pj4cOHCADz74gD59+tzVPdi6dSu7du3i9OnT2NjYADB58mSWL1/OF198Qd++fQHIzc0lOjoaR0dHAF5++WU2btzI+PHjOXfuHDExMcTGxtK6dWsAFixYQPny5Y3rlC5dmuLFi+Po6Iibm5tZDDk5OcyZM4cqVaoA0L9/f8aOHXvLmKOiooiMjLyrfoqIiEjRpBELKRKOHTtG165dqVy5Mk5OTnh5eQHXvti7urryzDPPsGjRIgBOnDjB9u3bCQ0NBSA5ORkrKyvq1atntFe1alVKlSpVoGu/+OKLXLx4kcqVK9OnTx++/vprrly5AkCbNm2oWLEilStX5uWXX2bRokVcuHDB7PzGjRubTScKCAjg2LFjXL169a7uQVJSEllZWZQpUwYHBwdjO3HihDEtDK4tvL6eVAC4u7sbozM//fQTOTk5RmIE4OzsjI+PT4FisLe3N5KKv7d9M2FhYWRkZBjbqVOnCtxfERERKVqUWEiR0K5dO/7880/mzZvHzp072blzJwCXL18GIDQ0lC+++IKcnBxiY2OpVauWMV3JUh4eHiQnJzN79mzs7Ox48803ad68OTk5OTg6OrJ3714WL16Mu7s7o0ePpk6dOpw9e/aeXPtGWVlZuLu7k5iYaLYlJyczbNgwo16JEiXMzjOZTOTm5t6TGG7W9u3Wi9jY2ODk5GS2iYiIyKNJiYU89M6cOUNycjLvvPMOrVu3xtfXl7/++susTvv27bl06RJr1qwhNjbWGK0A8PHx4cqVK+zbt884dvz48Xxt3I6dnR3t2rVjxowZxMXFsX37dg4cOACAlZUVQUFBTJo0if3795Oamsr3339vnHs9Cbpux44dVKtWjeLFi9/VfahXrx6//fYbVlZWVK1a1WwrW7ZsgdqoXLkyJUqUICEhwTiWkZHB0aNHzepZW1vf9YiKiIiIPN60xkIeeqVKlaJMmTL897//xd3dnbS0NEaOHGlWp2TJknTo0IHw8HAOHz5M165djbLq1asTFBRE3759+eijjyhRogRvv/02dnZ2+Z54dDPR0dFcvXqVRo0aYW9vz2effYadnR0VK1bk22+/5aeffqJ58+aUKlWK1atXk5ubaza1KC0tjSFDhvDaa6+xd+9eZs6cyZQpU+76PgQFBREQEECHDh2YNGkS3t7e/Prrr6xatYqOHTsa60dux9HRkR49ejBs2DBKly7NE088wZgxYyhWrJjZvfDy8uKHH37gpZdewsbGpsCJi4iIiDy+NGIhD71ixYqxZMkS9uzZw1NPPcXgwYN5//3389ULDQ0lKSmJZs2a4enpaVa2cOFCypUrR/PmzenYsSN9+vTB0dERW1vbO17fxcWFefPm0bRpU2rXrs2GDRv45ptvKFOmDC4uLnz11Ve0atUKX19f5syZw+LFi6lZs6Zxfvfu3bl48SINGzakX79+DBw40FhofTdMJhOrV6+mefPmvPLKK3h7e/PSSy9x8uRJypUrV+B2pk6dSkBAAM899xxBQUE0bdoUX19fs3sxduxYUlNTqVKlCq6urncdq4iIiDx+THn/9IH6IkXYzz//jIeHBxs2bDCejnQ/BAYGUrdu3Yf6Ldbnz5/nySefZMqUKfTq1eu+XiszMxNnZ2c8Bi2jmI39fb1WUZE6sW1hhyAiInJb139/Z2Rk3Ha9pKZCyWPh+++/Jysri1q1apGens7w4cPx8vLK986Jx8G+ffs4cuQIDRs2JCMjw3hcbPv27Qs5MhERESnKNBVKHgs5OTn85z//oWbNmnTs2BFXV1fi4uIoUaIEixYtMnt8643bjVOa7rUtW7bc8roODg737bpw7f0XderUISgoiPPnz7NlyxatoxARERGLaCqUPPbOnTvH//73v5uWlShRgooVK96X6168eJFffvnlluVVq1a9L9ctTJoKlZ+mQomIyMOuoFOhlFiIyANT0P8xiYiIyMOjoL+/NRVKREREREQspsRCREREREQspsRCREREREQspsRCREREREQspsRCREREREQsphfkicgD99SYtXrcrBQ5ejSwiMjtacRCREREREQspsRCREREREQspsRCREREREQspsRCREREREQspsRCRAokMDCQQYMGFXYYIiIi8pBSYiEiIiIiIhZTYiHyCLt8+XJhhyAiIiKPCSUWIgUUGBhI//796d+/P87OzpQtW5bw8HDy8vIA+PTTT/H398fR0RE3Nze6devG6dOnzdpYuXIl1apVw9bWlpYtWxITE4PJZOLs2bNGna1bt9KsWTPs7Ozw8PBgwIABnD9/vkAxenl5MW7cOLp3746TkxN9+/YFYMSIEXh7e2Nvb0/lypUJDw8nJyfHOC8iIoK6devy6aef4uXlhbOzMy+99BLnzp275bVWrVqFs7MzixYtKugtFBERkUeYEguRuxATE4OVlRW7du1i+vTpTJ06lfnz5wOQk5PDuHHjSEpKYvny5aSmptKzZ0/j3BMnTvDCCy/QoUMHkpKSeO211xg1apRZ+ykpKYSEhPD888+zf/9+li5dytatW+nfv3+BY5w8eTJ16tRh3759hIeHA+Do6Eh0dDSHDh1i+vTpzJs3jw8++CDftZcvX863337Lt99+y+bNm5k4ceJNrxEbG0vXrl1ZtGgRoaGht4wlOzubzMxMs01EREQeTaa8639uFZHbCgwM5PTp0/z444+YTCYARo4cycqVKzl06FC++rt376ZBgwacO3cOBwcHRo4cyapVqzhw4IBR55133mH8+PH89ddfuLi40Lt3b4oXL87cuXONOlu3bqVFixacP38eW1vb28bo5eWFn58fX3/99W3rTZ48mSVLlrB7927g2ojF+++/z2+//YajoyMAw4cP54cffmDHjh1G/+vWrUu1atUYNWoUK1asoEWLFre9TkREBJGRkfmOewxapjdvS5GjN2+LyOMqMzMTZ2dnMjIycHJyumU9jViI3IXGjRsbSQVAQEAAx44d4+rVq+zZs4d27drh6emJo6Oj8aU7LS0NgOTkZBo0aGDWXsOGDc32k5KSiI6OxsHBwdiCg4PJzc3lxIkTBYrR398/37GlS5fStGlT3NzccHBw4J133jHius7Ly8tIKgDc3d3zTeX64osvGDx4MOvXr79jUgEQFhZGRkaGsZ06dapAfRAREZGiR4mFyD1w6dIlgoODcXJyYtGiRSQkJBijBnezgDorK4vXXnuNxMREY0tKSuLYsWNUqVKlQG2ULFnSbH/79u2Ehobyf//3f3z77bfs27ePUaNG5YurRIkSZvsmk4nc3FyzY35+fri6uvLJJ59QkMFOGxsbnJyczDYRERF5NFkVdgAiRcnOnTvN9nfs2EG1atU4cuQIZ86cYeLEiXh4eAAY04yu8/HxYfXq1WbHEhISzPbr1avHoUOHqFq16j2Ledu2bVSsWNFsPcfJkyf/UVtVqlRhypQpBAYGUrx4cWbNmnWvwhQREZEiTiMWInchLS2NIUOGkJyczOLFi5k5cyYDBw7E09MTa2trZs6cyU8//cTKlSsZN26c2bmvvfYaR44cYcSIERw9epRly5YRHR0NYEyvGjFiBNu2baN///4kJiZy7NgxVqxYcVeLt/+uWrVqpKWlsWTJElJSUpgxY8Yd12Dcjre3N5s2beLLL7/UC/NERETEoMRC5C50796dixcv0rBhQ/r168fAgQPp27cvrq6uREdH8/nnn1OjRg0mTpzI5MmTzc6tVKkSX3zxBV999RW1a9fmo48+MkYRbGxsAKhduzabN2/m6NGjNGvWDD8/P0aPHk358uX/ccz/+te/GDx4MP3796du3bps27bNeFrUP+Xj48P333/P4sWLefvtty1qS0RERB4NeiqUSAFdfyrStGnT7lmb48ePZ86cOY/NoubrT5XQU6GkKNJToUTkcVXQp0JpjYXIAzR79mwaNGhAmTJliI+P5/3337dompOIiIjIw0KJhcgDdOzYMd59913+/PNPPD09efvttwkLCyvQuVu2bOHZZ5+9ZXlWVta9ClNERETkrmkqlEgRcfHiRX755Zdblt/LJ0ndL5oKJUWZpkKJyONKU6FEHjF2dnZFInkQERGRx5MSCxF54A5GButleSIiIo8YPW5WREREREQspsRCREREREQspsRCREREREQspsRCREREREQspsXbIvLAPTVm7QN93KweEyoiInL/acRCREREREQspsRCREREREQspsRCREREREQspsRCREREREQspsRCiqTAwEAGDRpU2GEUWT179qRDhw7Gvu6niIiIWEqJhTx24uLiMJlMnD17trBDKbCIiAjq1q1739r/6quvGDdunLHv5eXFtGnT7tv1RERE5NGjx82KPEJycnIoUaLEXZ9XunTp+xCNiIiIPE40YiGPhFWrVuHs7MyiRYv49NNP8ff3x9HRETc3N7p168bp06cBSE1NpWXLlgCUKlUKk8lEz549SU1NxWQy5dsCAwMLdP34+HgCAwOxt7enVKlSBAcH89dffwGQm5tLVFQUlSpVws7Ojjp16vDFF18Y514fQdm4cSP+/v7Y29vTpEkTkpOTAYiOjiYyMpKkpCQjrujoaABMJhMfffQR//rXvyhZsiTjx4/n6tWr9OrVy7iej48P06dPv238N06FCgwM5OTJkwwePNi43vnz53FycjKLG2D58uWULFmSc+fOFeg+iYiIyKNLiYUUebGxsXTt2pVFixYRGhpKTk4O48aNIykpieXLl5OamkrPnj0B8PDw4MsvvwQgOTmZ9PR0pk+fjoeHB+np6ca2b98+ypQpQ/Pmze94/cTERFq3bk2NGjXYvn07W7dupV27dly9ehWAqKgoFi5cyJw5c/jxxx8ZPHgw//73v9m8ebNZO6NGjWLKlCns3r0bKysrXn31VQC6dOnC22+/Tc2aNY34unTpYpwXERFBx44dOXDgAK+++iq5ublUqFCBzz//nEOHDjF69Gj+85//sGzZsgLdz6+++ooKFSowduxY43olS5bkpZdeYsGCBWZ1FyxYwAsvvICjo+NN28rOziYzM9NsExERkUeTpkJJkfbhhx8yatQovvnmG1q0aAFgfCEHqFy5MjNmzKBBgwZkZWXh4OBgTPt54okncHFxMeq6ubkBcOnSJTp06EBAQAARERF3jGHSpEn4+/sze/Zs41jNmjWBa1+sJ0yYwIYNGwgICDBi2rp1K3PnzjViBhg/fryxP3LkSNq2bculS5ews7PDwcEBKysrI8YbdevWjVdeecXsWGRkpPHvSpUqsX37dpYtW0bnzp3v2J/SpUtTvHhxY8Tnut69e9OkSRPS09Nxd3fn9OnTrF69mg0bNtyyraioKLNYRERE5NGlEQspsr744gsGDx7M+vXrzb6g79mzh3bt2uHp6Ymjo6NRlpaWVqB2X331Vc6dO0dsbCzFit35P5HrIxY3c/z4cS5cuECbNm1wcHAwtoULF5KSkmJWt3bt2sa/3d3dAYwpXLfj7++f79iHH35I/fr1cXV1xcHBgf/+978F7v+tNGzYkJo1axITEwPAZ599RsWKFW87qhMWFkZGRoaxnTp1yqIYRERE5OGlEQspsvz8/Ni7dy+ffPIJ/v7+xlqA4OBggoODWbRoEa6urqSlpREcHMzly5fv2Oa7777L2rVr2bVr1y2n9/ydnZ3dLcuysrKAa2tAnnzySbMyGxsbs/0bF12bTCbg2vqMOylZsqTZ/pIlSxg6dChTpkwhICAAR0dH3n//fXbu3HnHtu6kd+/efPjhh4wcOZIFCxbwyiuvGLHejI2NTb5+ioiIyKNJIxZSZFWpUoVNmzaxYsUK3nrrLQCOHDnCmTNnmDhxIs2aNaN69er5/upvbW0NYKyBuO7LL79k7NixLFu2jCpVqhQ4jtq1a7Nx48abltWoUQMbGxvS0tKoWrWq2ebh4VHga1hbW+eL91bi4+Np0qQJb775Jn5+flStWjXf6Mg/vd6///1vTp48yYwZMzh06BA9evS4q3ZFRETk0aXEQoo0b29vNm3axJdffsmgQYPw9PTE2tqamTNn8tNPP7Fy5Uqz9zMAVKxYEZPJxLfffsvvv/9OVlYWBw8epHv37owYMYKaNWvy22+/8dtvv/Hnn3/eMYawsDASEhJ488032b9/P0eOHOGjjz7ijz/+wNHRkaFDhzJ48GBiYmJISUlh7969zJw505hSVBBeXl6cOHGCxMRE/vjjD7Kzs29Zt1q1auzevZu1a9dy9OhRwsPDSUhIKPC1rl/vhx9+4JdffuGPP/4wjpcqVYpOnToxbNgwnnnmGSpUqHBX7YqIiMijS4mFFHk+Pj58//33LF68mIkTJxIdHc3nn39OjRo1mDhxIpMnTzar/+STTxIZGcnIkSMpV64c/fv3Z/fu3Vy4cIF3330Xd3d3Y+vUqdMdr+/t7c26detISkqiYcOGBAQEsGLFCqysrs00HDduHOHh4URFReHr60tISAirVq2iUqVKBe7j888/T0hICC1btsTV1ZXFixffsu5rr71Gp06d6NKlC40aNeLMmTO8+eabBb4WwNixY0lNTaVKlSq4urqalfXq1YvLly+bLZIXERERMeXl5eUVdhAiUnR8+umnDB48mF9//dWYVlZQmZmZODs74zFoGcVs7O9ThPmlTmz7wK4lIiLyqLn++zsjIwMnJ6db1tPibREpkAsXLpCens7EiRN57bXX7jqpEBERkUebpkKJ3MGzzz5r9qjYG7cJEyYUdngPzKRJk6hevTpubm6EhYUVdjgiIiLykNFUKJE7+OWXX7h48eJNy0qXLm28cE/uTFOhREREih5NhRK5R/7+/gkRERERyU+JhYg8cAcjg2/7Fw8REREperTGQkRERERELKbEQkRERERELKbEQkRERERELKbEQkRERERELKbF2yLywD01Zu1tHzerx8OKiIgUPRqxEBERERERiymxEBERERERiymxEBERERERiymxEBERERERiymxEBERERERiymxEHmIBQYGMmjQoLs6JzU1FZPJRGJi4i3rxMXFYTKZOHv2rEXxiYiIiFynx82KPGI8PDxIT0+nbNmyhR2KiIiIPEaUWIg8Qi5fvoy1tTVubm6FHYqIiIg8ZjQVSuQhd+XKFfr374+zszNly5YlPDycvLw8ALy8vBg3bhzdu3fHycmJvn373nQq1OrVq/H29sbOzo6WLVuSmpqa7zrz5s3Dw8MDe3t7OnbsyNSpU3FxcTGrs2LFCurVq4etrS2VK1cmMjKSK1eu3Mfei4iISFGhxELkIRcTE4OVlRW7du1i+vTpTJ06lfnz5xvlkydPpk6dOuzbt4/w8PB85586dYpOnTrRrl07EhMT6d27NyNHjjSrEx8fz+uvv87AgQNJTEykTZs2jB8/3qzOli1b6N69OwMHDuTQoUPMnTuX6OjofPVulJ2dTWZmptkmIiIijyZT3vU/fYrIQycwMJDTp0/z448/YjKZABg5ciQrV67k0KFDeHl54efnx9dff22ck5qaSqVKldi3bx9169blP//5DytWrODHH3806owcOZL33nuPv/76CxcXF1566SWysrL49ttvjTr//ve/+fbbb40F3kFBQbRu3ZqwsDCjzmeffcbw4cP59ddfbxp/REQEkZGR+Y57DFpGMRv7W/Y7dWLbgt0gERERue8yMzNxdnYmIyMDJyenW9bTiIXIQ65x48ZGUgEQEBDAsWPHuHr1KgD+/v63Pf/w4cM0atTI7FhAQIDZfnJyMg0bNjQ79vf9pKQkxo4di4ODg7H16dOH9PR0Lly4cNNrh4WFkZGRYWynTp26fWdFRESkyNLibZEirmTJkg/kOllZWURGRtKpU6d8Zba2tjc9x8bGBhsbm/sdmoiIiDwElFiIPOR27txptr9jxw6qVatG8eLFC3S+r68vK1euzNfGjXx8fEhISDA79vf9evXqkZycTNWqVQsauoiIiDxGNBVK5CGXlpbGkCFDSE5OZvHixcycOZOBAwcW+PzXX3+dY8eOMWzYMJKTk4mNjSU6OtqszltvvcXq1auZOnUqx44dY+7cuXz33XdmU7BGjx7NwoULiYyM5Mcff+Tw4cMsWbKEd9555151VURERIowJRYiD7nu3btz8eJFGjZsSL9+/Rg4cCB9+/Yt8Pmenp58+eWXLF++nDp16jBnzhwmTJhgVqdp06bMmTOHqVOnUqdOHdasWcPgwYPNpjgFBwfz7bffsm7dOho0aEDjxo354IMPqFix4j3rq4iIiBRdeiqUiNxUnz59OHLkCFu2bLlnbV5/qoSeCiUiIlJ0FPSpUFpjISLAtfdhtGnThpIlS/Ldd98RExPD7NmzCzssERERKSKUWIgIALt27WLSpEmcO3eOypUrM2PGDHr37l3YYYmIiEgRocRCRABYtmxZYYcgIiIiRZgSCxF54A5GBt92jqaIiIgUPXoqlIiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWEyJhYiIiIiIWEyLt0XkgXtqzNrbviDvdvTyPBERkYeTRixERERERMRiSixERERERMRiSixERERERMRiSixERERERMRiSixERERERMRiSixE5Kbi4uIwmUycPXu2sEMRERGRIkCJhYiIiIiIWEyJhYiIiIiIWEyJhUgRl5uby6RJk6hatSo2NjZ4enoyfvx4WrVqRf/+/c3q/v7771hbW7Nx40YAsrOzGTFiBB4eHtjY2FC1alU+/vjjW15r69atNGvWDDs7Ozw8PBgwYADnz5+/r/0TERGRokGJhUgRFxYWxsSJEwkPD+fQoUPExsZSrlw5evfuTWxsLNnZ2Ubdzz77jCeffJJWrVoB0L17dxYvXsyMGTM4fPgwc+fOxcHB4abXSUlJISQkhOeff579+/ezdOlStm7dmi95uVF2djaZmZlmm4iIiDyaTHl5eXmFHYSI/DPnzp3D1dWVWbNm0bt3b7OyS5cuUb58eebMmUPnzp0BqFOnDp06dWLMmDEcPXoUHx8f1q9fT1BQUL624+LiaNmyJX/99RcuLi707t2b4sWLM3fuXKPO1q1badGiBefPn8fW1jZfGxEREURGRuY77jFoGcVs7P9Rn1Mntv1H54mIiMg/k5mZibOzMxkZGTg5Od2ynkYsRIqww4cPk52dTevWrfOV2dra8vLLL/PJJ58AsHfvXg4ePEjPnj0BSExMpHjx4rRo0aJA10pKSiI6OhoHBwdjCw4OJjc3lxMnTtz0nLCwMDIyMozt1KlT/6yjIiIi8tCzKuwAROSfs7Ozu2157969qVu3Lj///DMLFiygVatWVKxYsUDn/l1WVhavvfYaAwYMyFfm6el503NsbGywsbG5q+uIiIhI0aQRC5EirFq1atjZ2RmLsf+uVq1a+Pv7M2/ePGJjY3n11VfNynJzc9m8eXOBrlWvXj0OHTpE1apV823W1tb3pD8iIiJSdCmxECnCbG1tGTFiBMOHD2fhwoWkpKSwY8cOsyc79e7dm4kTJ5KXl0fHjh2N415eXvTo0YNXX32V5cuXc+LECeLi4li2bNlNrzVixAi2bdtG//79SUxM5NixY6xYseK2i7dFRETk8aHEQqSICw8P5+2332b06NH4+vrSpUsXTp8+bZR37doVKysrunbtmm+B9UcffcQLL7zAm2++SfXq1enTp88tHx9bu3ZtNm/ezNGjR2nWrBl+fn6MHj2a8uXL39f+iYiISNGgp0KJPOJSU1OpUqUKCQkJ1KtXr1Bjuf5UCT0VSkREpOgo6FOhtHhb5BGVk5PDmTNneOedd2jcuHGhJxUiIiLyaNNUKJFHVHx8PO7u7iQkJDBnzpzCDkdEREQecRqxEHlEBQYGopmOIiIi8qAosRCRB+5gZPBt52iKiIhI0aOpUCIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjE9FUpEHrinxqz9R2/e1lu3RUREHl4asRAREREREYspsRAREREREYspsRAREREREYspsRAREREREYspsRB5SAUGBjJo0KAHcq2IiAjq1q37QK4lIiIijyYlFiLC0KFD2bhxo7Hfs2dPOnToUHgBiYiISJGjx82KCA4ODjg4OBR2GCIiIlKEacRC5CFw/vx5unfvjoODA+7u7kyZMsWsPDs7m6FDh/Lkk09SsmRJGjVqRFxcnFEeHR2Ni4sLa9euxdfXFwcHB0JCQkhPTzfqxMXF0bBhQ0qWLImLiwtNmzbl5MmTgPlUqIiICGJiYlixYgUmkwmTyURcXBytWrWif//+ZnH9/vvvWFtbm412iIiIyONJiYXIQ2DYsGFs3ryZFStWsG7dOuLi4ti7d69R3r9/f7Zv386SJUvYv38/L774IiEhIRw7dsyoc+HCBSZPnsynn37KDz/8QFpaGkOHDgXgypUrdOjQgRYtWrB//362b99O3759MZlM+WIZOnQonTt3NhKT9PR0mjRpQu/evYmNjSU7O9uo+9lnn/Hkk0/SqlWrm/YrOzubzMxMs01EREQeTUosRApZVlYWH3/8MZMnT6Z169bUqlWLmJgYrly5AkBaWhoLFizg888/p1mzZlSpUoWhQ4fy9NNPs2DBAqOdnJwc5syZg7+/P/Xq1aN///7GSEJmZiYZGRk899xzVKlSBV9fX3r06IGnp2e+eBwcHLCzs8PGxgY3Nzfc3NywtramU6dOAKxYscKoGx0dTc+ePW+aoABERUXh7OxsbB4eHvfsvomIiMjDRYmFSCFLSUnh8uXLNGrUyDhWunRpfHx8ADhw4ABXr17F29vbWAvh4ODA5s2bSUlJMc6xt7enSpUqxr67uzunT5822uvZsyfBwcG0a9eO6dOnm02TKghbW1tefvllPvnkEwD27t3LwYMH6dmz5y3PCQsLIyMjw9hOnTp1V9cUERGRokOLt0UecllZWRQvXpw9e/ZQvHhxs7IbF1yXKFHCrMxkMpGXl2fsL1iwgAEDBrBmzRqWLl3KO++8w/r162ncuHGBY+nduzd169bl559/ZsGCBbRq1YqKFSvesr6NjQ02NjYFbl9ERESKLo1YiBSyKlWqUKJECXbu3Gkc++uvvzh69CgAfn5+XL16ldOnT1O1alWzzc3N7a6u5efnR1hYGNu2beOpp54iNjb2pvWsra25evVqvuO1atXC39+fefPmERsby6uvvnpX1xcREZFHlxILkULm4OBAr169GDZsGN9//70xvahYsWv/eXp7exMaGkr37t356quvOHHiBLt27SIqKopVq1YV6BonTpwgLCyM7du3c/LkSdatW8exY8fw9fW9aX0vLy/2799PcnIyf/zxBzk5OUZZ7969mThxInl5eXTs2NHyGyAiIiKPBCUWIg+B999/n2bNmtGuXTuCgoJ4+umnqV+/vlG+YMECunfvzttvv42Pjw8dOnQgISHhpouvb8be3p4jR47w/PPP4+3tTd++fenXrx+vvfbaTev36dMHHx8f/P39cXV1JT4+3ijr2rUrVlZWdO3aFVtbW8s6LiIiIo8MU96Nk7BFRO4gNTWVKlWqkJCQQL169e7q3MzMzGtPhxq0jGI29nd/7Ylt7/ocERERscz1398ZGRk4OTndsp4Wb4tIgeTk5HDmzBneeecdGjdufNdJhYiIiDzaNBVKRAokPj4ed3d3EhISmDNnTmGHIyIiIg8ZjViISIEEBgaimZMiIiJyKxqxEBERERERi2nEQkQeuIORwbdd/CUiIiJFj0YsRERERETEYkosRERERETEYkosRERERETEYkosRERERETEYlq8LSIP3FNj1v6jN2/fjN7GLSIi8nDQiIWIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMiYWIiIiIiFhMiYXIIyguLg6TycTZs2cLOxQRERF5TCixEBERERERiymxEBERERERiymxELlBYGAgAwYMYPjw4ZQuXRo3NzciIiIASE1NxWQykZiYaNQ/e/YsJpOJuLg44P9NQVq7di1+fn7Y2dnRqlUrTp8+zXfffYevry9OTk5069aNCxcuFCim3NxcoqKiqFSpEnZ2dtSpU4cvvvjCrM7q1avx9vbGzs6Oli1bkpqamq+defPm4eHhgb29PR07dmTq1Km4uLiY1VmxYgX16tXD1taWypUrExkZyZUrVwDIy8sjIiICT09PbGxsKF++PAMGDChQH0REROTRpxfkifxNTEwMQ4YMYefOnWzfvp2ePXvStGlTqlWrVuA2IiIimDVrFvb29nTu3JnOnTtjY2NDbGwsWVlZdOzYkZkzZzJixIg7thUVFcVnn33GnDlzqFatGj/88AP//ve/cXV1pUWLFpw6dYpOnTrRr18/+vbty+7du3n77bfN2oiPj+f111/nvffe41//+hcbNmwgPDzcrM6WLVvo3r07M2bMoFmzZqSkpNC3b18AxowZw5dffskHH3zAkiVLqFmzJr/99htJSUm3jT07O5vs7GxjPzMzs6C3UERERIoYJRYif1O7dm3GjBkDQLVq1Zg1axYbN268q8Ti3XffpWnTpgD06tWLsLAwUlJSqFy5MgAvvPACmzZtumNikZ2dzYQJE9iwYQMBAQEAVK5cma1btzJ37lxatGjBRx99RJUqVZgyZQoAPj4+HDhwgPfee89oZ+bMmTz77LMMHToUAG9vb7Zt28a3335r1ImMjGTkyJH06NHDuM64ceMYPnw4Y8aMIS0tDTc3N4KCgihRogSenp40bNjwtvFHRUURGRlZ4PsmIiIiRZemQon8Te3atc323d3dOX369D9uo1y5ctjb2xtJxfVjBWnz+PHjXLhwgTZt2uDg4GBsCxcuJCUlBYDDhw/TqFEjs/OuJyHXJScn50sC/r6flJTE2LFjza7Tp08f0tPTuXDhAi+++CIXL16kcuXK9OnTh6+//tqYJnUrYWFhZGRkGNupU6fu2GcREREpmjRiIfI3JUqUMNs3mUzk5uZSrNi1PDwvL88oy8nJuWMbJpPplm3eSVZWFgCrVq3iySefNCuzsbG54/l3Iysri8jISDp16pSvzNbWFg8PD5KTk9mwYQPr16/nzTff5P3332fz5s35+ndjjPc6ThEREXk4KbEQKSBXV1cA0tPT8fPzAzBbyH0/1KhRAxsbG9LS0mjRosVN6/j6+rJy5UqzYzt27DDb9/HxISEhwezY3/fr1atHcnIyVatWvWU8dnZ2tGvXjnbt2tGvXz+qV6/OgQMHqFev3t10S0RERB5BSixECsjOzo7GjRszceJEKlWqxOnTp3nnnXfu6zUdHR0ZOnQogwcPJjc3l6effpqMjAzi4+NxcnKiR48evP7660yZMoVhw4bRu3dv9uzZQ3R0tFk7b731Fs2bN2fq1Km0a9eO77//nu+++w6TyWTUGT16NM899xyenp688MILFCtWjKSkJA4ePMi7775LdHQ0V69epVGjRtjb2/PZZ59hZ2dHxYoV7+s9EBERkaJBayxE7sInn3zClStXqF+/PoMGDeLdd9+979ccN24c4eHhREVF4evrS0hICKtWraJSpUoAeHp68uWXX7J8+XLq1KnDnDlzmDBhglkbTZs2Zc6cOUydOpU6deqwZs0aBg8ejK2trVEnODiYb7/9lnXr1tGgQQMaN27MBx98YCQOLi4uzJs3j6ZNm1K7dm02bNjAN998Q5kyZe77PRAREZGHnynvxgnjIvLY6NOnD0eOHGHLli0P7JqZmZk4OzvjMWgZxWzs70mbqRPb3pN2RERE5Oau//7OyMjAycnplvU0FUrkMTF58mTatGlDyZIl+e6774iJiWH27NmFHZaIiIg8IpRYiBSitLQ0atSoccvyQ4cO4enpeU+utWvXLiZNmsS5c+eoXLkyM2bMoHfv3vekbRERERElFiKFqHz58rd9slT58uXv2bWWLVt2z9oSERER+TslFiKFyMrK6raPdxUREREpKpRYiMgDdzAy+LaLv0RERKTo0eNmRURERETEYkosRERERETEYkosRERERETEYkosRERERETEYlq8LSIP3FNj1t6zN2/fit7ILSIi8mBpxEJERERERCymxEJERERERCymxEJERERERCymxEJERERERCymxEJERERERCymxELkMRYREUHdunULOwwRERF5BCixEBERERERiymxEBERERERiymxEPmbwMBABgwYwPDhwyldujRubm5EREQAkJqaislkIjEx0ah/9uxZTCYTcXFxAMTFxWEymVi7di1+fn7Y2dnRqlUrTp8+zXfffYevry9OTk5069aNCxcuWBzTdWlpabRv3x4HBwecnJzo3Lkz//vf/8zqTJw4kXLlyuHo6EivXr24dOlSvmvNnz8fX19fbG1tqV69OrNnzzbKLl++TP/+/XF3d8fW1paKFSsSFRVVoD6IiIjIo02JhchNxMTEULJkSXbu3MmkSZMYO3Ys69evv6s2IiIimDVrFtu2bePUqVN07tyZadOmERsby6pVq1i3bh0zZ868JzHl5ubSvn17/vzzTzZv3sz69ev56aef6NKli3H+smXLiIiIYMKECezevRt3d3ezpAFg0aJFjB49mvHjx3P48GEmTJhAeHg4MTExAMyYMYOVK1eybNkykpOTWbRoEV5eXreMOTs7m8zMTLNNREREHk1WhR2AyMOodu3ajBkzBoBq1aoxa9YsNm7cSLVq1QrcxrvvvkvTpk0B6NWrF2FhYaSkpFC5cmUAXnjhBTZt2sSIESMsiqlNmzZs3LiRAwcOcOLECTw8PABYuHAhNWvWJCEhgQYNGjBt2jR69epFr169jPg2bNhgNmoxZswYpkyZQqdOnQCoVKkShw4dYu7cufTo0YO0tDSqVavG008/jclkomLFireNOSoqisjIyALfMxERESm6NGIhchO1a9c223d3d+f06dP/uI1y5cphb29vJBXXj91Nm7eL6fDhw3h4eBhJBUCNGjVwcXHh8OHDRp1GjRqZtREQEGD8+/z586SkpNCrVy8cHByM7d133yUlJQWAnj17kpiYiI+PDwMGDGDdunW3jTksLIyMjAxjO3XqVIH7KyIiIkWLRixEbqJEiRJm+yaTidzcXIoVu5aL5+XlGWU5OTl3bMNkMt2yTUtjuleysrIAmDdvXr4EpHjx4gDUq1ePEydO8N1337FhwwY6d+5MUFAQX3zxxU3btLGxwcbG5p7FKCIiIg8vjViI3AVXV1cA0tPTjWM3LuQuLL6+vpw6dcpsRODQoUOcPXuWGjVqGHV27txpdt6OHTuMf5crV47y5cvz008/UbVqVbOtUqVKRj0nJye6dOnCvHnzWLp0KV9++SV//vnnfe6hiIiIPOw0YiFyF+zs7GjcuDETJ06kUqVKnD59mnfeeaewwyIoKIhatWoRGhrKtGnTuHLlCm+++SYtWrTA398fgIEDB9KzZ0/8/f1p2rQpixYt4scffzSbnhUZGcmAAQNwdnYmJCSE7Oxsdu/ezV9//cWQIUOYOnUq7u7u+Pn5UaxYMT7//HPc3NxwcXEppJ6LiIjIw0IjFiJ36ZNPPuHKlSvUr1+fQYMG8e677xZ2SJhMJlasWEGpUqVo3rw5QUFBVK5cmaVLlxp1unTpQnh4OMOHD6d+/fqcPHmSN954w6yd3r17M3/+fBYsWECtWrVo0aIF0dHRxoiFo6MjkyZNwt/fnwYNGpCamsrq1auNKWIiIiLy+DLl3ThZXETkPsrMzMTZ2RmPQcsoZmN/X6+VOrHtfW1fRETkcXH993dGRgZOTk63rKc/M4qIiIiIiMWUWIgUsrS0NLPHu/59S0tLK+wQRURERO5Ii7dFCln58uVv+2Sp8uXLP7hgRERERP4hrbEQkQemoHM0RURE5OGhNRYiIiIiIvLAKLEQERERERGLKbEQERERERGLKbEQERERERGL6alQIvLAPTVm7X1/QZ6IiBQOvaD08aURCxERERERsZgSCxERERERsZgSCxERERERsZgSCxERERERsZgSCxERERERsZgSC5GbMJlMLF++vLDDEBERESkylFjIYy0iIoK6devmO56ens6zzz774AMSERERKaL0HguRm3BzcyvsEIqUy5cvY21tXdhhiIiISCHSiIUUqvPnz9O9e3ccHBxwd3dnypQpBAYGMmjQIODmU5JcXFyIjo429k+dOkXnzp1xcXGhdOnStG/fntTUVKM8Li6Ohg0bUrJkSVxcXGjatCknT54kOjqayMhIkpKSMJlMmEwmo92/X/fAgQO0atUKOzs7ypQpQ9++fcnKyjLKe/bsSYcOHZg8eTLu7u6UKVOGfv36kZOTU6D78Omnn+Lv74+joyNubm5069aN06dPm/XBZDKxceNG/P39sbe3p0mTJiQnJxt1kpKSaNmyJY6Ojjg5OVG/fn12795NXl4erq6ufPHFF0bdunXr4u7ubuxv3boVGxsbLly4AMDZs2fp3bs3rq6uODk50apVK5KSkoz610d65s+fT6VKlbC1tS1QP0VEROTRpcRCCtWwYcPYvHkzK1asYN26dcTFxbF3794Cn5+Tk0NwcDCOjo5s2bKF+Ph4HBwcCAkJ4fLly1y5coUOHTrQokUL9u/fz/bt2+nbty8mk4kuXbrw9ttvU7NmTdLT00lPT6dLly75rnH+/HmCg4MpVaoUCQkJfP7552zYsIH+/fub1du0aRMpKSls2rSJmJgYoqOjzRKgO/Vj3LhxJCUlsXz5clJTU+nZs2e+eqNGjWLKlCns3r0bKysrXn31VaMsNDSUChUqkJCQwJ49exg5ciQlSpTAZDLRvHlz4uLiAPjrr784fPgwFy9e5MiRIwBs3ryZBg0aYG9/7W3YL774IqdPn+a7775jz5491KtXj9atW/Pnn38a1zt+/DhffvklX331FYmJiTftV3Z2NpmZmWabiIiIPJo0FUoKTVZWFh9//DGfffYZrVu3BiAmJoYKFSoUuI2lS5eSm5vL/PnzMZlMACxYsAAXFxfi4uLw9/cnIyOD5557jipVqgDg6+trnO/g4ICVldVtpz7FxsZy6dIlFi5cSMmSJQGYNWsW7dq147333qNcuXIAlCpVilmzZlG8eHGqV69O27Zt2bhxI3369LljP25MECpXrsyMGTNo0KABWVlZODg4GGXjx4+nRYsWAIwcOZK2bdty6dIlbG1tSUtLY9iwYVSvXh2AatWqGecFBgYyd+5cAH744Qf8/Pxwc3MjLi6O6tWrExcXZ7S7detWdu3axenTp7GxsQFg8uTJLF++nC+++IK+ffsC16Y/LVy4EFdX11v2KyoqisjIyDv2X0RERIo+jVhIoUlJSeHy5cs0atTIOFa6dGl8fHwK3EZSUhLHjx/H0dERBwcHHBwcKF26NJcuXSIlJYXSpUvTs2dPgoODadeuHdOnTyc9Pf2u4jx8+DB16tQxkgqApk2bkpubazYVqWbNmhQvXtzYd3d3N5vOdDt79uyhXbt2eHp64ujoaHzJT0tLM6tXu3Zts/YB4xpDhgyhd+/eBAUFMXHiRFJSUoy6LVq04NChQ/z+++9s3ryZwMBAAgMDiYuLIycnh23bthEYGAhcu6dZWVmUKVPGuKcODg6cOHHCrM2KFSveNqkACAsLIyMjw9hOnTpVoPshIiIiRY8SC3momUwm8vLyzI7duG4hKyuL+vXrk5iYaLYdPXqUbt26AddGMLZv306TJk1YunQp3t7e7Nix457HWqJEiXyx5+bm3vG861OtnJycWLRoEQkJCXz99dfAtVGBW13j+gjN9WtERETw448/0rZtW77//ntq1KhhtFOrVi1Kly7N5s2bzRKLzZs3k5CQQE5ODk2aNAGu3VN3d/d89zQ5OZlhw4YZ178x0boVGxsbnJyczDYRERF5NGkqlBSaKlWqUKJECXbu3Imnpydwbf7/0aNHjb/Yu7q6mo0wHDt2zFhgDFCvXj2WLl3KE088cdsvrX5+fvj5+REWFkZAQACxsbE0btwYa2trrl69ets4fX19iY6O5vz588aX6fj4eIoVK3ZXoyu3cuTIEc6cOcPEiRPx8PAAYPfu3f+oLW9vb7y9vRk8eDBdu3ZlwYIFdOzYEZPJRLNmzVixYgU//vgjTz/9NPb29mRnZzN37lz8/f2NvtWrV4/ffvsNKysrvLy8LO6fiIiIPB40YiGFxsHBgV69ejFs2DC+//57Dh48SM+ePSlW7P99LFu1asWsWbPYt28fu3fv5vXXXzf7q31oaChly5alffv2bNmyhRMnThAXF8eAAQP4+eefOXHiBGFhYWzfvp2TJ0+ybt06jh07Zqyz8PLy4sSJEyQmJvLHH3+QnZ2dL87Q0FBsbW3p0aMHBw8eZNOmTbz11lu8/PLLxvoKS3h6emJtbc3MmTP56aefWLlyJePGjburNi5evEj//v2Ji4vj5MmTxMfHk5CQYLaeJDAwkMWLF1O3bl0cHBwoVqwYzZs3Z9GiRUYiBxAUFERAQAAdOnRg3bp1pKamsm3bNkaNGvWPEx4RERF59CmxkEL1/vvv06xZM9q1a0dQUBBPP/009evXN8qnTJmCh4cHzZo1o1u3bgwdOtR4chGAvb09P/zwA56ennTq1AlfX1969erFpUuXcHJywt7eniNHjvD888/j7e1N37596devH6+99hoAzz//PCEhIbRs2RJXV1cWL16cL0Z7e3vWrl3Ln3/+SYMGDXjhhRdo3bo1s2bNuif3wNXVlejoaD7//HNq1KjBxIkTmTx58l21Ubx4cc6cOUP37t3x9vamc+fOPPvss2YLp1u0aMHVq1eNtRRwLdn4+zGTycTq1atp3rw5r7zyCt7e3rz00kucPHnyniRSIiIi8mgy5f19ArtIIQsMDKRu3bpMmzatsEOReywzMxNnZ2c8Bi2jmI39nU8QEZEiJ3Vi28IOQe6x67+/MzIybjv1XCMWIiIiIiJiMSUWIvfZli1bzB7b+vdNRERE5FGgp0LJQ+f6G6IfFf7+/rd8M7WIiIjIo0JrLETkgSnoHE0RERF5eGiNhYiIiIiIPDBKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJKLERERERExGJWhR2AiDw+8vLyAMjMzCzkSERERKSgrv/evv57/FaUWIjIA3PmzBkAPDw8CjkSERERuVvnzp3D2dn5luVKLETkgSldujQAaWlpt/0f0+MqMzMTDw8PTp06hZOTU2GH89DR/bk93Z/b0/25Pd2f23vc709eXh7nzp2jfPnyt62nxEJEHphixa4t63J2dn4s/8dcUE5OTro/t6H7c3u6P7en+3N7uj+39zjfn4L8QVCLt0VERERExGJKLERERERExGJKLETkgbGxsWHMmDHY2NgUdigPJd2f29P9uT3dn9vT/bk93Z/b0/0pGFPenZ4bJSIiIiIicgcasRAREREREYspsRAREREREYspsRAREREREYspsRAREREREYspsRCRB+LDDz/Ey8sLW1tbGjVqxK5duwo7pIdGREQEJpPJbKtevXphh1VofvjhB9q1a0f58uUxmUwsX77crDwvL4/Ro0fj7u6OnZ0dQUFBHDt2rHCCfcDudG969uyZ77MUEhJSOMEWgqioKBo0aICjoyNPPPEEHTp0IDk52azOpUuX6NevH2XKlMHBwYHnn3+e//3vf4UU8YNVkPsTGBiY7zP0+uuvF1LED9ZHH31E7dq1jZfgBQQE8N133xnlj/Nnp6CUWIjIfbd06VKGDBnCmDFj2Lt3L3Xq1CE4OJjTp08XdmgPjZo1a5Kenm5sW7duLeyQCs358+epU6cOH3744U3LJ02axIwZM5gzZw47d+6kZMmSBAcHc+nSpQcc6YN3p3sDEBISYvZZWrx48QOMsHBt3ryZfv36sWPHDtavX09OTg7PPPMM58+fN+oMHjyYb775hs8//5zNmzfz66+/0qlTp0KM+sEpyP0B6NOnj9lnaNKkSYUU8YNVoUIFJk6cyJ49e9i9ezetWrWiffv2/Pjjj8Dj/dkpsDwRkfusYcOGef369TP2r169mle+fPm8qKioQozq4TFmzJi8OnXqFHYYDyUg7+uvvzb2c3Nz89zc3PLef/9949jZs2fzbGxs8hYvXlwIERaev9+bvLy8vB49euS1b9++UOJ5GJ0+fToPyNu8eXNeXt61z0qJEiXyPv/8c6PO4cOH84C87du3F1aYhebv9ycvLy+vRYsWeQMHDiy8oB4ypUqVyps/f74+OwWkEQsRua8uX77Mnj17CAoKMo4VK1aMoKAgtm/fXoiRPVyOHTtG+fLlqVy5MqGhoaSlpRV2SA+lEydO8Ntvv5l9npydnWnUqJE+T/+/uLg4nnjiCXx8fHjjjTc4c+ZMYYdUaDIyMgAoXbo0AHv27CEnJ8fs81O9enU8PT0fy8/P3+/PdYsWLaJs2bI89dRThIWFceHChcIIr1BdvXqVJUuWcP78eQICAvTZKSCrwg5ARB5tf/zxB1evXqVcuXJmx8uVK8eRI0cKKaqHS6NGjYiOjsbHx4f09HQiIyNp1qwZBw8exNHRsbDDe6j89ttvADf9PF0ve5yFhITQqVMnKlWqREpKCv/5z3949tln2b59O8WLFy/s8B6o3NxcBg0aRNOmTXnqqaeAa58fa2trXFxczOo+jp+fm90fgG7dulGxYkXKly/P/v37GTFiBMnJyXz11VeFGO2Dc+DAAQICArh06RIODg58/fXX1KhRg8TERH12CkCJhYhIIXv22WeNf9euXZtGjRpRsWJFli1bRq9evQoxMilqXnrpJePftWrVonbt2lSpUoW4uDhat25diJE9eP369ePgwYOP9Xql27nV/enbt6/x71q1auHu7k7r1q1JSUmhSpUqDzrMB87Hx4fExEQyMjL44osv6NGjB5s3by7ssIoMTYUSkfuqbNmyFC9ePN+TM/73v//h5uZWSFE93FxcXPD29ub48eOFHcpD5/pnRp+ngqlcuTJly5Z97D5L/fv359tvv2XTpk1UqFDBOO7m5sbly5c5e/asWf3H7fNzq/tzM40aNQJ4bD5D1tbWVK1alfr16xMVFUWdOnWYPn26PjsFpMRCRO4ra2tr6tevz8aNG41jubm5bNy4kYCAgEKM7OGVlZVFSkoK7u7uhR3KQ6dSpUq4ubmZfZ4yMzPZuXOnPk838fPPP3PmzJnH5rOUl5dH//79+frrr/n++++pVKmSWXn9+vUpUaKE2ecnOTmZtLS0x+Lzc6f7czOJiYkAj81n6O9yc3PJzs5+7D87BaWpUCJy3w0ZMoQePXrg7+9Pw4YNmTZtGufPn+eVV14p7NAeCkOHDqVdu3ZUrFiRX3/9lTFjxlC8eHG6du1a2KEViqysLLO/jp44cYLExERKly6Np6cngwYN4t1336VatWpUqlSJ8PBwypcvT4cOHQov6AfkdvemdOnSREZG8vzzz+Pm5kZKSgrDhw+natWqBAcHF2LUD06/fv2IjY1lxYoVODo6GnPfnZ2dsbOzw9nZmV69ejFkyBBKly6Nk5MTb731FgEBATRu3LiQo7//7nR/UlJSiI2N5f/+7/8oU6YM+/fvZ/DgwTRv3pzatWsXcvT3X1hYGM8++yyenp6cO3eO2NhY4uLiWLt27WP/2Smwwn4slYg8HmbOnJnn6emZZ21tndewYcO8HTt2FHZID40uXbrkubu751lbW+c9+eSTeV26dMk7fvx4YYdVaDZt2pQH5Nt69OiRl5d37ZGz4eHheeXKlcuzsbHJa926dV5ycnLhBv2A3O7eXLhwIe+ZZ57Jc3V1zStRokRexYoV8/r06ZP322+/FXbYD8zN7g2Qt2DBAqPOxYsX89588828UqVK5dnb2+d17NgxLz09vfCCfoDudH/S0tLymjdvnle6dOk8GxubvKpVq+YNGzYsLyMjo3ADf0BeffXVvIoVK+ZZW1vnubq65rVu3Tpv3bp1Rvnj/NkpKFNeXl7eg0xkRERERETk0aM1FiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYjElFiIiIiIiYrH/D7soGAC0ryJQAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -641,6 +687,7 @@
     "features_importance = model.get_feature_importance(data=test_pool)\n",
     "\n",
     "plt.barh(col_names, features_importance)\n",
+    "plt.tight_layout()\n",
     "plt.savefig(Path(save_path) / \"features_importance.png\")\n",
     "plt.show()"
    ]


### PR DESCRIPTION
I added updated Catboost training & reranking. The training is now correctly training on only train & val; not touching test. This updated dataset is pushed to HuggingFace ([T5-Large](s-nlp/Mintaka_Graph_Features_T5-large-ssm), [T5-XL](s-nlp/Mintaka_Graph_Features_T5-xl-ssm) ). I've also fixed the scaling issue (`fit_transform` & `transform`). Furthermore, training is now not using the TDA TFIDF vectors.

As usual, the jupyter notebook can be converted to `py` script to train **and** rerank. Please check inside the notebook for configuration parameters.
```bash
jupyter nbconvert --to script catboost_features.ipynb
python3 catboost_features.ipynb
```
Else, one could also train via the native script, then load the trained model to the notebook above to rerank
```
python3 train_catboost_regressor.py run_name
```
Load model saved from the above train, place the path in the notebook and rerank